### PR TITLE
Make everything async

### DIFF
--- a/azure/worker/__init__.py
+++ b/azure/worker/__init__.py
@@ -1,32 +1,14 @@
-import queue
-
-import grpc
-
-try:
-    from . import protos
-except ImportError:
-    raise RuntimeError(
-        'cannot start worker; generate pb2/grpc files in azure/worker/protos')
-
+from . import aio_compat
 from . import dispatcher
 
 
+async def start_async(host, port, worker_id, request_id):
+    disp = await dispatcher.Dispatcher.connect(
+        host, port, worker_id, request_id,
+        connect_timeout=5.0)
+
+    await disp.dispatch_forever()
+
+
 def start(host: str, port: int, worker_id: str, request_id: str):
-    channel = grpc.insecure_channel(f'{host}:{port}')
-    stub = protos.FunctionRpcStub(channel)
-
-    def gen(q):
-        while True:
-            yield q.get()
-
-    response_queue = queue.Queue()
-    response_queue.put(protos.StreamingMessage(
-        request_id=request_id,
-        start_stream=protos.StartStream(
-            worker_id=worker_id)))
-
-    resp_stream = stub.EventStream(gen(response_queue))
-    disp = dispatcher.Dispatcher(response_queue, request_id)
-
-    for resp in resp_stream:
-        disp.dispatch(resp)
+    return aio_compat.run(start_async(host, port, worker_id, request_id))

--- a/azure/worker/aio_compat.py
+++ b/azure/worker/aio_compat.py
@@ -1,0 +1,76 @@
+"""Backport of asyncio.run() function from Python 3.7.
+
+Source: https://github.com/python/cpython/blob/
+            bd093355a6aaf2f4ca3ed153e195da57870a55eb/Lib/asyncio/runners.py
+"""
+
+
+import asyncio
+
+
+def run(main, *, debug=False):
+    """Run a coroutine.
+
+    This function runs the passed coroutine, taking care of
+    managing the asyncio event loop and finalizing asynchronous
+    generators.
+
+    This function cannot be called when another asyncio event loop is
+    running in the same thread.
+
+    If debug is True, the event loop will be run in debug mode.
+    This function always creates a new event loop and closes it at the end.
+
+    It should be used as a main entry point for asyncio programs, and should
+    ideally only be called once.
+    """
+    if asyncio._get_running_loop() is not None:
+        raise RuntimeError(
+            "asyncio.run() cannot be called from a running event loop")
+
+    if not asyncio.iscoroutine(main):
+        raise ValueError("a coroutine was expected, got {!r}".format(main))
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        loop.set_debug(debug)
+        return loop.run_until_complete(main)
+    finally:
+        try:
+            _cancel_all_tasks(loop)
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+
+def _cancel_all_tasks(loop):
+    to_cancel = [task for task in asyncio.Task.all_tasks(loop)
+                 if not task.done()]
+    if not to_cancel:
+        return
+
+    for task in to_cancel:
+        task.cancel()
+
+    loop.run_until_complete(
+        asyncio.gather(*to_cancel, loop=loop, return_exceptions=True))
+
+    for task in to_cancel:
+        if task.cancelled():
+            continue
+        if task.exception() is not None:
+            loop.call_exception_handler({
+                'message': 'unhandled exception during asyncio.run() shutdown',
+                'exception': task.exception(),
+                'task': task,
+            })
+
+
+try:
+    # Try to import the 'run' function from asyncio.
+    from asyncio import run  # NoQA
+except ImportError:
+    # Python <= 3.6
+    pass

--- a/azure/worker/dispatcher.py
+++ b/azure/worker/dispatcher.py
@@ -3,9 +3,14 @@
 Implements loading and execution of Python workers.
 """
 
-
+import asyncio
+import inspect
+import queue
+import threading
 import typing
 import traceback
+
+import grpc
 
 from . import bind
 from . import loader
@@ -14,6 +19,7 @@ from . import types
 
 
 class FunctionInfo(typing.NamedTuple):
+
     func: object
     name: str
     directory: str
@@ -21,38 +27,83 @@ class FunctionInfo(typing.NamedTuple):
 
 class Dispatcher:
 
-    def __init__(self, response_queue, request_id):
-        self._response_queue = response_queue
+    _GRPC_STOP_RESPONSE = object()
+
+    def __init__(self, loop, host, port, worker_id, request_id,
+                 grpc_connect_timeout):
+        self._loop = loop
+        self._host = host
+        self._port = port
         self._request_id = request_id
+        self._worker_id = worker_id
         self._functions = {}
+
+        self._grpc_connect_timeout = grpc_connect_timeout
+        self._grpc_resp_queue = queue.Queue()
+        self._grpc_connected_fut = loop.create_future()
+        self._grpc_thread = threading.Thread(
+            name='grpc-thread', target=self.__poll_grpc)
+
+    @classmethod
+    async def connect(cls, host, port, worker_id, request_id,
+                      connect_timeout):
+        loop = asyncio._get_running_loop()
+        disp = cls(loop, host, port, worker_id, request_id, connect_timeout)
+        disp._grpc_thread.start()
+        await disp._grpc_connected_fut
+        return disp
+
+    async def dispatch_forever(self):
+        forever = self._loop.create_future()
+
+        self._grpc_resp_queue.put_nowait(
+            protos.StreamingMessage(
+                request_id=self.request_id,
+                start_stream=protos.StartStream(
+                    worker_id=self.worker_id)))
+
+        try:
+            await forever
+        finally:
+            self.stop()
+
+    def stop(self):
+        if self._grpc_thread is not None:
+            self._grpc_resp_queue.put_nowait(self._GRPC_STOP_RESPONSE)
+            self._grpc_thread.join()
+            self._grpc_thread = None
 
     @property
     def request_id(self):
         return self._request_id
 
-    def serialize_exception(self, exc):
+    @property
+    def worker_id(self):
+        return self._worker_id
+
+    def _serialize_exception(self, exc):
         return protos.RpcException(
             message=f'{type(exc).__name__}: {exc.args[0]}',
             stack_trace=''.join(traceback.format_tb(exc.__traceback__)))
 
-    def dispatch(self, request):
+    async def _dispatch_grpc_request(self, request):
         content_type = request.WhichOneof('content')
-        method = getattr(self, f'handle__{content_type}', None)
-        if method is None:
+        request_handler = getattr(self, f'_handle__{content_type}', None)
+        if request_handler is None:
             raise RuntimeError(
                 f'unknown StreamingMessage content type {content_type}')
 
-        resp = method(request)
-        self._response_queue.put(resp)
+        resp = await request_handler(request)
+        self._grpc_resp_queue.put_nowait(resp)
 
-    def handle__worker_init_request(self, req):
+    async def _handle__worker_init_request(self, req):
         return protos.StreamingMessage(
             request_id=self.request_id,
             worker_init_response=protos.WorkerInitResponse(
                 result=protos.StatusResult(
                     status=protos.StatusResult.Success)))
 
-    def handle__function_load_request(self, req):
+    async def _handle__function_load_request(self, req):
         func_request = req.function_load_request
         function_id = func_request.function_id
 
@@ -81,9 +132,9 @@ class Dispatcher:
                     function_id=function_id,
                     result=protos.StatusResult(
                         status=protos.StatusResult.Failure,
-                        exception=self.serialize_exception(ex))))
+                        exception=self._serialize_exception(ex))))
 
-    def handle__invocation_request(self, req):
+    async def _handle__invocation_request(self, req):
         invoc_request = req.invocation_request
 
         invocation_id = invoc_request.invocation_id
@@ -102,6 +153,9 @@ class Dispatcher:
             call_result = bind.call(
                 funcinfo.func, ctx, invoc_request.input_data)
 
+            if inspect.iscoroutine(call_result):
+                call_result = await call_result
+
             return protos.StreamingMessage(
                 request_id=self.request_id,
                 invocation_response=protos.InvocationResponse(
@@ -117,4 +171,32 @@ class Dispatcher:
                     invocation_id=invocation_id,
                     result=protos.StatusResult(
                         status=protos.StatusResult.Failure,
-                        exception=self.serialize_exception(ex))))
+                        exception=self._serialize_exception(ex))))
+
+    def __poll_grpc(self):
+        channel = grpc.insecure_channel(f'{self._host}:{self._port}')
+
+        try:
+            grpc.channel_ready_future(channel).result(
+                timeout=self._grpc_connect_timeout)
+        except Exception as ex:
+            self._loop.call_soon_threadsafe(
+                self._grpc_connected_fut.set_exception, ex)
+            return
+        else:
+            self._loop.call_soon_threadsafe(
+                self._grpc_connected_fut.set_result, True)
+
+        stub = protos.FunctionRpcStub(channel)
+
+        def gen(resp_queue):
+            while True:
+                msg = resp_queue.get()
+                if msg is self._GRPC_STOP_RESPONSE:
+                    return
+                yield msg
+
+        grpc_req_stream = stub.EventStream(gen(self._grpc_resp_queue))
+        for req in grpc_req_stream:
+            self._loop.call_soon_threadsafe(
+                self._loop.create_task, self._dispatch_grpc_request(req))

--- a/azure/worker/tests/functions/async_return_str/function.json
+++ b/azure/worker/tests/functions/async_return_str/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure/worker/tests/functions/async_return_str/main.py
+++ b/azure/worker/tests/functions/async_return_str/main.py
@@ -1,0 +1,7 @@
+import asyncio
+import azure.functions
+
+
+async def main(req: azure.functions.HttpRequest, context):
+    await asyncio.sleep(0.1)
+    return 'Hello Async World!'

--- a/azure/worker/tests/functions/host.json
+++ b/azure/worker/tests/functions/host.json
@@ -30,6 +30,7 @@
     },
     "functionTimeout": "00:05:00",
     "functions": [
+        "async_return_str",
         "return_str",
         "return_context",
         "return_request",

--- a/azure/worker/tests/test_functions.py
+++ b/azure/worker/tests/test_functions.py
@@ -19,6 +19,11 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'Hello World!')
 
+    def test_async_return_str(self):
+        r = self.webhost.request('GET', 'async_return_str')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'Hello Async World!')
+
     def test_return_context(self):
         r = self.webhost.request('GET', 'return_context')
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
The gRPC dispatcher is now async and async/await functions are now supported (see the `tests/functions/async_return_str` function)