### PR TITLE
prohibit "inout" bindings; ensure functions without "$return" work; don't crash on unsupported messages

### DIFF
--- a/azure/worker/dispatcher.py
+++ b/azure/worker/dispatcher.py
@@ -184,6 +184,11 @@ class Dispatcher(metaclass=DispatcherMeta):
         bindings = {}
         return_binding = None
         for name, desc in metadata.bindings.items():
+            if desc.direction == protos.BindingInfo.inout:
+                raise TypeError(
+                    f'cannot load the {func_name} function: '
+                    f'"inout" bindings are not supported')
+
             if name == '$return':
                 # TODO:
                 # *  add proper gRPC->Python type reflection;
@@ -191,6 +196,12 @@ class Dispatcher(metaclass=DispatcherMeta):
                 # * enforce return type of a function call in Python;
                 # * use the return type information to marshal the result into
                 #   a correct gRPC type.
+
+                if desc.direction != protos.BindingInfo.out:
+                    raise TypeError(
+                        f'cannot load the {func_name} function: '
+                        f'"$return" binding must have direction set to "out"')
+
                 return_binding = desc  # NoQA
             else:
                 bindings[name] = desc

--- a/azure/worker/protos/__init__.py
+++ b/azure/worker/protos/__init__.py
@@ -13,6 +13,7 @@ from .FunctionRpc_pb2 import (  # NoQA
     FunctionLoadResponse,
     InvocationRequest,
     InvocationResponse,
+    WorkerHeartbeat,
     BindingInfo,
     StatusResult,
     RpcException,

--- a/azure/worker/tests/broken_functions/inout_param/function.json
+++ b/azure/worker/tests/broken_functions/inout_param/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "inout",
+      "name": "abc"
+    }
+  ]
+}

--- a/azure/worker/tests/broken_functions/inout_param/main.py
+++ b/azure/worker/tests/broken_functions/inout_param/main.py
@@ -1,0 +1,2 @@
+def main(req, abc):
+    return 'trust me, it is OK!'

--- a/azure/worker/tests/broken_functions/return_param_in/function.json
+++ b/azure/worker/tests/broken_functions/return_param_in/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "in",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure/worker/tests/broken_functions/return_param_in/main.py
+++ b/azure/worker/tests/broken_functions/return_param_in/main.py
@@ -1,0 +1,2 @@
+def main(req):
+    return 'trust me, it is OK!'

--- a/azure/worker/tests/functions/no_return/function.json
+++ b/azure/worker/tests/functions/no_return/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    }
+  ]
+}

--- a/azure/worker/tests/functions/no_return/main.py
+++ b/azure/worker/tests/functions/no_return/main.py
@@ -1,0 +1,8 @@
+import logging
+
+
+logger = logging.getLogger('test')
+
+
+def main(req):
+    logger.error('hi')

--- a/azure/worker/tests/test_broken_functions.py
+++ b/azure/worker/tests/test_broken_functions.py
@@ -93,3 +93,33 @@ class TestMockHost(testutils.AsyncTestCase):
                              protos.StatusResult.Failure)
 
             self.assertIn('SyntaxError', r.response.result.exception.message)
+
+    async def test_load_broken__inout_param(self):
+        async with testutils.start_mockhost(
+                script_root='broken_functions') as host:
+
+            func_id, r = await host.load_function('inout_param')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Failure)
+
+            self.assertRegex(
+                r.response.result.exception.message,
+                r'.*cannot load the inout_param function'
+                r'.*"inout" bindings.*')
+
+    async def test_load_broken__return_param_in(self):
+        async with testutils.start_mockhost(
+                script_root='broken_functions') as host:
+
+            func_id, r = await host.load_function('return_param_in')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Failure)
+
+            self.assertRegex(
+                r.response.result.exception.message,
+                r'.*cannot load the return_param_in function'
+                r'.*"\$return" .* set to "out"')

--- a/azure/worker/tests/test_functions.py
+++ b/azure/worker/tests/test_functions.py
@@ -19,6 +19,10 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'Hello World!')
 
+    def test_no_return(self):
+        r = self.webhost.request('GET', 'no_return')
+        self.assertEqual(r.status_code, 204)
+
     def test_async_return_str(self):
         r = self.webhost.request('GET', 'async_return_str')
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
cc @asavaritayal @christopheranderson 