### PR TITLE
Load function modules into a reserved namespace package

### DIFF
--- a/azure/worker/dispatcher.py
+++ b/azure/worker/dispatcher.py
@@ -5,14 +5,11 @@ Implements loading and execution of Python workers.
 
 import asyncio
 import concurrent.futures
-import inspect
 import logging
 import queue
 import threading
-import typing
 import traceback
 
-import azure.functions as azf
 import grpc
 
 from . import functions
@@ -81,6 +78,9 @@ class Dispatcher(metaclass=DispatcherMeta):
                 'there can be only one running dispatcher per process')
 
         self._old_task_factory = self._loop.get_task_factory()
+
+        loader.install()
+
         DispatcherMeta.__current_dispatcher__ = self
         try:
             forever = self._loop.create_future()
@@ -103,6 +103,9 @@ class Dispatcher(metaclass=DispatcherMeta):
                 root_logger.removeHandler(logging_handler)
         finally:
             DispatcherMeta.__current_dispatcher__ = None
+
+            loader.uninstall()
+
             self._loop.set_task_factory(self._old_task_factory)
             self.stop()
 

--- a/azure/worker/tests/broken_functions/import_error/function.json
+++ b/azure/worker/tests/broken_functions/import_error/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure/worker/tests/broken_functions/import_error/main.py
+++ b/azure/worker/tests/broken_functions/import_error/main.py
@@ -1,0 +1,5 @@
+from sys import __nonexistent  # should raise ImportError
+
+
+def main(req):
+    __nonexistent()

--- a/azure/worker/tests/broken_functions/module_not_found_error/function.json
+++ b/azure/worker/tests/broken_functions/module_not_found_error/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure/worker/tests/broken_functions/module_not_found_error/main.py
+++ b/azure/worker/tests/broken_functions/module_not_found_error/main.py
@@ -1,0 +1,5 @@
+from __nonexistent import foo  # should raise ModuleNotFoundError
+
+
+def main(req):
+    foo()

--- a/azure/worker/tests/http_functions/ping/README.md
+++ b/azure/worker/tests/http_functions/ping/README.md
@@ -1,0 +1,2 @@
+This function is used to check the host availability in tests.
+Please do not remove.

--- a/azure/worker/tests/http_functions/ping/function.json
+++ b/azure/worker/tests/http_functions/ping/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    }
+  ]
+}

--- a/azure/worker/tests/http_functions/ping/main.py
+++ b/azure/worker/tests/http_functions/ping/main.py
@@ -1,0 +1,2 @@
+def main(req):
+    return 'pong'

--- a/azure/worker/tests/load_functions/host.json
+++ b/azure/worker/tests/load_functions/host.json
@@ -1,0 +1,32 @@
+{
+    "http": {
+        "routePrefix": "api",
+        "maxConcurrentRequests": 5,
+        "maxOutstandingRequests": 30
+    },
+    "logger": {
+        "defaultLevel": "Trace",
+        "categoryLevels": {
+            "Worker": "Trace"
+        }
+    },
+    "queues": {
+        "visibilityTimeout": "00:00:10"
+    },
+    "swagger": {
+        "enabled": true
+    },
+    "eventHub": {
+        "maxBatchSize": 1000,
+        "prefetchCount": 1000,
+        "batchCheckpointFrequency": 1
+    },
+    "healthMonitor": {
+        "enabled": true,
+        "healthCheckInterval": "00:00:10",
+        "healthCheckWindow": "00:02:00",
+        "healthCheckThreshold": 6,
+        "counterThreshold": 0.80
+    },
+    "functionTimeout": "00:05:00",
+}

--- a/azure/worker/tests/load_functions/ping/README.md
+++ b/azure/worker/tests/load_functions/ping/README.md
@@ -1,0 +1,2 @@
+This function is used to check the host availability in tests.
+Please do not remove.

--- a/azure/worker/tests/load_functions/ping/function.json
+++ b/azure/worker/tests/load_functions/ping/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    }
+  ]
+}

--- a/azure/worker/tests/load_functions/ping/main.py
+++ b/azure/worker/tests/load_functions/ping/main.py
@@ -1,0 +1,2 @@
+def main(req):
+    return 'pong'

--- a/azure/worker/tests/load_functions/relimport/function.json
+++ b/azure/worker/tests/load_functions/relimport/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "string",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure/worker/tests/load_functions/relimport/main.py
+++ b/azure/worker/tests/load_functions/relimport/main.py
@@ -1,0 +1,5 @@
+from . import relative
+
+
+def main(req) -> str:
+    return relative.__name__

--- a/azure/worker/tests/load_functions/simple/function.json
+++ b/azure/worker/tests/load_functions/simple/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "string",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure/worker/tests/load_functions/simple/main.py
+++ b/azure/worker/tests/load_functions/simple/main.py
@@ -1,0 +1,2 @@
+def main(req) -> str:
+    return __name__

--- a/azure/worker/tests/load_functions/subdir/function.json
+++ b/azure/worker/tests/load_functions/subdir/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "sub/main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "string",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure/worker/tests/load_functions/subdir/sub/main.py
+++ b/azure/worker/tests/load_functions/subdir/sub/main.py
@@ -1,0 +1,2 @@
+def main(req) -> str:
+    return __name__

--- a/azure/worker/tests/test_broken_functions.py
+++ b/azure/worker/tests/test_broken_functions.py
@@ -94,6 +94,32 @@ class TestMockHost(testutils.AsyncTestCase):
 
             self.assertIn('SyntaxError', r.response.result.exception.message)
 
+    async def test_load_broken__module_not_found_error(self):
+        async with testutils.start_mockhost(
+                script_root='broken_functions') as host:
+
+            func_id, r = await host.load_function('module_not_found_error')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Failure)
+
+            self.assertIn('ModuleNotFoundError',
+                          r.response.result.exception.message)
+
+    async def test_load_broken__import_error(self):
+        async with testutils.start_mockhost(
+                script_root='broken_functions') as host:
+
+            func_id, r = await host.load_function('import_error')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Failure)
+
+            self.assertIn('ImportError',
+                          r.response.result.exception.message)
+
     async def test_load_broken__inout_param(self):
         async with testutils.start_mockhost(
                 script_root='broken_functions') as host:

--- a/azure/worker/tests/test_http_functions.py
+++ b/azure/worker/tests/test_http_functions.py
@@ -1,18 +1,11 @@
-import unittest
-
 from azure.worker import testutils
 
 
-class TestFunctions(unittest.TestCase):
+class TestHttpFunctions(testutils.WebHostTestCase):
 
     @classmethod
-    def setUpClass(cls):
-        cls.webhost = testutils.start_webhost()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.webhost.close()
-        cls.webhost = None
+    def get_script_dir(cls):
+        return 'http_functions'
 
     def test_return_str(self):
         r = self.webhost.request('GET', 'return_str')

--- a/azure/worker/tests/test_loader.py
+++ b/azure/worker/tests/test_loader.py
@@ -1,0 +1,23 @@
+from azure.worker import testutils
+
+
+class TestLoader(testutils.WebHostTestCase):
+
+    @classmethod
+    def get_script_dir(cls):
+        return 'load_functions'
+
+    def test_loader_simple(self):
+        r = self.webhost.request('GET', 'simple')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, '__azure__.simple.main')
+
+    def test_loader_subdir(self):
+        r = self.webhost.request('GET', 'subdir')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, '__azure__.subdir.sub.main')
+
+    def test_loader_relimport(self):
+        r = self.webhost.request('GET', 'relimport')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, '__azure__.relimport.relative')


### PR DESCRIPTION
Function modules are now loaded into the special `__azure__` namespace
package to prevent any possible name collisions with non-function
modules.  Additionally, this makes it possible to avoid polluting
`sys.modules` too much.

The loaded module structure is as follows:

```
__azure__.
    func1.
       func1mod
    func2.
       func1mod
    ...
```

Closes: #26