### PR TITLE
Encapsulate type conversion and validation logic in classes.

### DIFF
--- a/azure/worker/dispatcher.py
+++ b/azure/worker/dispatcher.py
@@ -15,8 +15,8 @@ import grpc
 from . import functions
 from . import loader
 from . import protos
-from . import type_converters
 from . import type_impl
+from . import type_meta
 
 
 class DispatcherMeta(type):
@@ -236,7 +236,7 @@ class Dispatcher(metaclass=DispatcherMeta):
             params = {}
             for pb in invoc_request.input_data:
                 pb_type = fi.input_types[pb.name]
-                params[pb.name] = type_converters.from_incoming_proto(
+                params[pb.name] = type_meta.from_incoming_proto(
                     pb_type, pb.data)
 
             if fi.requires_context:
@@ -263,7 +263,7 @@ class Dispatcher(metaclass=DispatcherMeta):
                         # Can "None" be marshaled into protos.TypedData?
                         continue
 
-                    rpc_val = type_converters.to_outgoing_proto(out_type, val)
+                    rpc_val = type_meta.to_outgoing_proto(out_type, val)
                     assert rpc_val is not None
 
                     output_data.append(
@@ -273,7 +273,7 @@ class Dispatcher(metaclass=DispatcherMeta):
 
             return_value = None
             if fi.return_type is not None:
-                return_value = type_converters.to_outgoing_proto(
+                return_value = type_meta.to_outgoing_proto(
                     fi.return_type, call_result)
 
             return protos.StreamingMessage(

--- a/azure/worker/functions.py
+++ b/azure/worker/functions.py
@@ -3,7 +3,7 @@ import typing
 
 import azure.functions as azf
 
-from . import type_converters
+from . import type_meta
 from . import protos
 
 
@@ -16,9 +16,9 @@ class FunctionInfo(typing.NamedTuple):
     requires_context: bool
     is_async: bool
 
-    input_types: typing.Mapping[str, type_converters.BindType]
-    output_types: typing.Mapping[str, type_converters.BindType]
-    return_type: typing.Optional[type_converters.BindType]
+    input_types: typing.Mapping[str, type_meta.Binding]
+    output_types: typing.Mapping[str, type_meta.Binding]
+    return_type: typing.Optional[type_meta.Binding]
 
 
 class FunctionLoadError(RuntimeError):
@@ -69,7 +69,7 @@ class Registry:
                         f'"$return" binding must have direction set to "out"')
 
                 try:
-                    return_type = type_converters.BindType(desc.type)
+                    return_type = type_meta.Binding(desc.type)
                 except ValueError:
                     raise FunctionLoadError(
                         func_name,
@@ -130,7 +130,7 @@ class Registry:
                     f'is azure.functions.Out in Python')
 
             try:
-                param_bind_type = type_converters.BindType(desc.type)
+                param_bind_type = type_meta.Binding(desc.type)
             except ValueError:
                 raise FunctionLoadError(
                     func_name,
@@ -150,7 +150,7 @@ class Registry:
                 else:
                     param_py_type = param.annotation
                 if param_py_type:
-                    if not type_converters.check_bind_type_matches_py_type(
+                    if not type_meta.check_bind_type_matches_py_type(
                             param_bind_type, param_py_type):
                         raise FunctionLoadError(
                             func_name,
@@ -170,7 +170,7 @@ class Registry:
                     func_name,
                     f'return annotation should not be azure.functions.Out')
 
-            if not type_converters.check_bind_type_matches_py_type(
+            if not type_meta.check_bind_type_matches_py_type(
                     return_type, ra):
                 raise FunctionLoadError(
                     func_name,

--- a/azure/worker/type_converters.py
+++ b/azure/worker/type_converters.py
@@ -1,5 +1,3 @@
-"""Facilities for marshaling and unmarshaling gRPC objects."""
-
 import json
 import typing
 
@@ -7,123 +5,32 @@ import azure.functions as azf
 
 from . import protos
 from . import type_impl
-
-from .type_impl import BindType
-
-
-def check_bind_type_matches_py_type(
-        bind_type: BindType, py_type: type) -> bool:
-
-    if bind_type in {BindType.string, BindType.json}:
-        return issubclass(py_type, str)
-
-    if bind_type is BindType.bytes:
-        return issubclass(py_type, (bytes, bytearray))
-
-    if bind_type is BindType.int:
-        return issubclass(py_type, int)
-
-    if bind_type is BindType.double:
-        return issubclass(py_type, float)
-
-    if bind_type is BindType.http:
-        # We support returning 'str' values from http returning functions
-        # as a shortcut for returning `HttpResponse(status_code=200, data)`.
-        return issubclass(py_type, (azf.HttpResponse, str))
-
-    if bind_type is BindType.httpTrigger:
-        return issubclass(py_type, azf.HttpRequest)
-
-    if bind_type is BindType.timerTrigger:
-        return issubclass(py_type, azf.TimerRequest)
-
-    raise TypeError(
-        f'bind type {bind_type} does not have a corresponding Python type')
+from . import type_meta
 
 
-def from_incoming_proto(o_type: BindType, o: protos.TypedData) -> typing.Any:
-    dt = o.WhichOneof('data')
+class HttpResponseConverter(type_meta.OutConverter,
+                            binding=type_meta.Binding.http):
 
-    if o_type is BindType.string and dt == 'string':
-        return o.string
+    @classmethod
+    def check_python_type(cls, pytype: type) -> bool:
+        return issubclass(pytype, (azf.HttpResponse, str))
 
-    if o_type is BindType.bytes and dt == 'bytes':
-        return o.bytes
+    @classmethod
+    def to_proto(cls, obj: typing.Any) -> protos.TypedData:
+        if isinstance(obj, str):
+            return protos.TypedData(string=obj)
 
-    if o_type is BindType.httpTrigger and dt == 'http':
-        body_rpc_val = o.http.body
-        body_rpc_type = body_rpc_val.WhichOneof('data')
-
-        body: typing.Any = None
-        if body_rpc_type == 'json':
-            body_type = BindType.json
-        elif body_rpc_type == 'string':
-            body_type = BindType.string
-        elif body_rpc_type == 'bytes':
-            body_type = BindType.bytes
-        elif body_rpc_type is None:
-            # Means an empty HTTP request body -- we don't want
-            # `HttpResponse.get_body()` to return None as it would
-            # make it more complicated to work with than necessary.
-            # Therefore we normalize the body to an empty bytes
-            # object.
-            body_type = BindType.bytes
-            body = ''
-        else:
-            raise TypeError(
-                f'unsupported HTTP body type from the incoming gRPC data: '
-                f'{body_rpc_type}')
-
-        if body is None:
-            # Not yet decoded from `body_rpc_val`.
-            body = from_incoming_proto(body_type, body_rpc_val)
-
-        return type_impl.HttpRequest(
-            method=o.http.method,
-            url=o.http.url,
-            headers=o.http.headers,
-            params=o.http.query,
-            body_type=body_type,
-            body=body)
-
-    if o_type is BindType.json and dt == 'json':
-        return o.json
-
-    if o_type is BindType.int and dt == 'int':
-        return o.int
-
-    if o_type is BindType.double and dt == 'double':
-        return o.double
-
-    if o_type is BindType.timerTrigger and dt == 'json':
-        info = json.loads(o.json)
-        return type_impl.TimerRequest(
-            past_due=info.get('IsPastDue', False))
-
-    raise TypeError(
-        f'unable to decode incoming TypedData: '
-        f'unsupported combination of TypedData field {dt!r} '
-        f'and expected Python type {o_type}')
-
-
-def to_outgoing_proto(o_type: BindType, o: typing.Any) -> protos.TypedData:
-    assert o is not None
-
-    if o_type is BindType.http:
-        if isinstance(o, str):
-            return to_outgoing_proto(BindType.string, o)
-
-        if isinstance(o, azf.HttpResponse):
-            status = o.status_code
-            headers = dict(o.headers)
+        if isinstance(obj, azf.HttpResponse):
+            status = obj.status_code
+            headers = dict(obj.headers)
             if 'content-type' not in headers:
-                if o.mimetype.startswith('text/'):
-                    ct = f'{o.mimetype}; charset={o.charset}'
+                if obj.mimetype.startswith('text/'):
+                    ct = f'{obj.mimetype}; charset={obj.charset}'
                 else:
-                    ct = f'{o.mimetype}'
+                    ct = f'{obj.mimetype}'
                 headers['content-type'] = ct
 
-            body = o.get_body()
+            body = obj.get_body()
             if body is not None:
                 body = protos.TypedData(bytes=body)
             else:
@@ -136,22 +43,67 @@ def to_outgoing_proto(o_type: BindType, o: typing.Any) -> protos.TypedData:
                     is_raw=True,
                     body=body))
 
-    elif o_type in {BindType.string, BindType.json}:
-        if isinstance(o, str):
-            return protos.TypedData(string=o)
+        raise NotImplementedError
 
-    elif o_type is BindType.bytes:
-        if isinstance(o, (bytes, bytearray)):
-            return protos.TypedData(bytes=o)
 
-    elif o_type is BindType.int:
-        if isinstance(o, int):
-            return protos.TypedData(int=o)
+class HttpRequestConverter(type_meta.InConverter,
+                           binding=type_meta.Binding.httpTrigger):
 
-    elif o_type is BindType.double:
-        if isinstance(o, float):
-            return protos.TypedData(double=o)
+    @classmethod
+    def check_python_type(cls, pytype: type) -> bool:
+        return issubclass(pytype, azf.HttpRequest)
 
-    raise TypeError(
-        f'unable to encode outgoing TypedData: '
-        f'unsupported type "{o_type}" for Python type "{type(o).__name__}"')
+    @classmethod
+    def from_proto(cls, data: protos.TypedData) -> typing.Any:
+        if data.WhichOneof('data') != 'http':
+            raise NotImplementedError
+
+        body_rpc_val = data.http.body
+        body_rpc_type = body_rpc_val.WhichOneof('data')
+
+        if body_rpc_type == 'json':
+            body_type = type_impl.TypedDataKind.json
+            body = body_rpc_val.json
+        elif body_rpc_type == 'string':
+            body_type = type_impl.TypedDataKind.string
+            body = body_rpc_val.string
+        elif body_rpc_type == 'bytes':
+            body_type = type_impl.TypedDataKind.bytes
+            body = body_rpc_val.bytes
+        elif body_rpc_type is None:
+            # Means an empty HTTP request body -- we don't want
+            # `HttpResponse.get_body()` to return None as it would
+            # make it more complicated to work with than necessary.
+            # Therefore we normalize the body to an empty bytes
+            # object.
+            body_type = type_impl.TypedDataKind.bytes
+            body = ''
+        else:
+            raise TypeError(
+                f'unsupported HTTP body type from the incoming gRPC data: '
+                f'{body_rpc_type}')
+
+        return type_impl.HttpRequest(
+            method=data.http.method,
+            url=data.http.url,
+            headers=data.http.headers,
+            params=data.http.query,
+            body_type=body_type,
+            body=body)
+
+
+class TimerRequestConverter(type_meta.InConverter,
+                            binding=type_meta.Binding.timerTrigger):
+
+    @classmethod
+    def check_python_type(cls, pytype: type) -> bool:
+        return issubclass(pytype, azf.TimerRequest)
+
+    @classmethod
+    def from_proto(cls, data: protos.TypedData) -> typing.Any:
+        if data.WhichOneof('data') != 'json':
+            raise NotImplementedError
+
+        info = json.loads(data.json)
+        return type_impl.TimerRequest(
+            past_due=info.get('IsPastDue', False))

--- a/azure/worker/type_impl.py
+++ b/azure/worker/type_impl.py
@@ -9,21 +9,15 @@ from azure.functions import _abc as azf_abc
 from azure.functions import _http as azf_http
 
 
-class BindType(str, enum.Enum):
-    """Type names that can appear in FunctionLoadRequest/BindingInfo.
+class TypedDataKind(enum.Enum):
 
-    See also the TypedData struct.
-    """
-
-    string = 'string'
-    json = 'json'
-    bytes = 'bytes'
-    http = 'http'
-    int = 'int'
-    double = 'double'
-
-    httpTrigger = 'httpTrigger'
-    timerTrigger = 'timerTrigger'
+    json = 1
+    string = 2
+    bytes = 3
+    int = 4
+    double = 5
+    http = 6
+    stream = 7
 
 
 class Out(azf_abc.Out):
@@ -65,7 +59,7 @@ class HttpRequest(azf_abc.HttpRequest):
     def __init__(self, method: str, url: str,
                  headers: typing.Mapping[str, str],
                  params: typing.Mapping[str, str],
-                 body_type: BindType,
+                 body_type: TypedDataKind,
                  body: typing.Union[str, bytes]) -> None:
         self.__method = method
         self.__url = url
@@ -94,7 +88,7 @@ class HttpRequest(azf_abc.HttpRequest):
         return self.__body
 
     def get_json(self) -> typing.Any:
-        if self.__body_type is BindType.json:
+        if self.__body_type is TypedDataKind.json:
             return json.loads(self.__body)
         raise ValueError('HTTP request does not have JSON data attached')
 

--- a/azure/worker/type_meta.py
+++ b/azure/worker/type_meta.py
@@ -1,0 +1,117 @@
+import abc
+import enum
+import typing
+
+from . import protos
+
+
+class Binding(str, enum.Enum):
+    """Supported binding types."""
+
+    http = 'http'
+    httpTrigger = 'httpTrigger'
+    timerTrigger = 'timerTrigger'
+
+
+class _ConverterMeta(abc.ABCMeta):
+
+    _check_py_type: typing.Mapping[Binding, typing.Callable[[type], bool]] = {}
+    _from_proto: typing.Mapping[Binding, typing.Callable] = {}
+    _to_proto: typing.Mapping[Binding, typing.Callable] = {}
+
+    def __new__(mcls, name, bases, dct, *, binding: typing.Optional[Binding]):
+        cls = super().__new__(mcls, name, bases, dct)
+        if binding is None:
+            return cls
+
+        if binding in mcls._check_py_type:
+            raise RuntimeError(
+                f'cannot register a converter for {binding} binding: '
+                f'another converter has already been registered')
+
+        mcls._check_py_type[binding] = getattr(cls, 'check_python_type')
+
+        if issubclass(cls, InConverter):
+            assert binding not in mcls._from_proto
+            mcls._from_proto[binding] = getattr(cls, 'from_proto')
+
+        if issubclass(cls, OutConverter):
+            assert binding not in mcls._to_proto
+            mcls._to_proto[binding] = getattr(cls, 'to_proto')
+
+        return cls
+
+
+class _BaseConverter(metaclass=_ConverterMeta, binding=None):
+
+    @abc.abstractclassmethod
+    def check_python_type(cls, pytype: type) -> bool:
+        pass
+
+
+class InConverter(_BaseConverter, binding=None):
+
+    @abc.abstractclassmethod
+    def from_proto(cls, data: protos.TypedData) -> typing.Any:
+        pass
+
+
+class OutConverter(_BaseConverter, binding=None):
+
+    @abc.abstractclassmethod
+    def to_proto(cls, obj: typing.Any) -> protos.TypedData:
+        pass
+
+
+def check_bind_type_matches_py_type(
+        binding: Binding, pytype: type) -> bool:
+
+    try:
+        checker = _ConverterMeta._check_py_type[binding]
+    except KeyError:
+        raise TypeError(
+            f'bind type {binding} does not have '
+            'a corresponding Python type') from None
+
+    return checker(pytype)
+
+
+def from_incoming_proto(binding: Binding, val: protos.TypedData) -> typing.Any:
+    converter = _ConverterMeta._from_proto.get(binding)
+
+    try:
+        try:
+            converter = _ConverterMeta._from_proto[binding]
+        except KeyError:
+            raise NotImplementedError
+        else:
+            return converter(val)
+    except NotImplementedError:
+        # Either there's no converter or a converter has failed.
+        dt = val.WhichOneof('data')
+
+        raise TypeError(
+            f'unable to decode incoming TypedData: '
+            f'unsupported combination of TypedData field {dt!r} '
+            f'and expected binding type {binding}')
+
+
+def to_outgoing_proto(binding: Binding, obj: typing.Any) -> protos.TypedData:
+    converter = _ConverterMeta._to_proto.get(binding)
+
+    try:
+        try:
+            converter = _ConverterMeta._to_proto[binding]
+        except KeyError:
+            raise NotImplementedError
+        else:
+            return converter(obj)
+    except NotImplementedError:
+        # Either there's no converter or a converter has failed.
+        raise TypeError(
+            f'unable to encode outgoing TypedData: '
+            f'unsupported type "{binding}" for '
+            f'Python type "{type(obj).__name__}"')
+
+
+from . import type_converters  # NoQA

--- a/tests/broken_functions/invalid_out_anno/function.json
+++ b/tests/broken_functions/invalid_out_anno/function.json
@@ -9,7 +9,7 @@
       "name": "req"
     },
     {
-      "type": "bytes",
+      "type": "http",
       "direction": "out",
       "name": "ret"
     }

--- a/tests/broken_functions/invalid_out_anno/main.py
+++ b/tests/broken_functions/invalid_out_anno/main.py
@@ -1,5 +1,5 @@
 import azure.functions as azf
 
 
-def main(req, ret: azf.Out[float]):
+def main(req, ret: azf.Out[azf.HttpRequest]):
     return 'trust me, it is OK!'

--- a/tests/http_functions/return_out/function.json
+++ b/tests/http_functions/return_out/function.json
@@ -11,12 +11,7 @@
     {
       "direction": "out",
       "name": "foo",
-      "type": "int"
-    },
-    {
-      "type": "http",
-      "direction": "out",
-      "name": "$return"
+      "type": "http"
     }
   ]
 }

--- a/tests/http_functions/return_out/main.py
+++ b/tests/http_functions/return_out/main.py
@@ -1,6 +1,5 @@
 import azure.functions as azf
 
 
-def main(req: azf.HttpRequest, foo: azf.Out[int]):
-    foo.set(42)
-    return 'wat'
+def main(req: azf.HttpRequest, foo: azf.Out[azf.HttpResponse]):
+    foo.set(azf.HttpResponse(body='hello', status_code=201))

--- a/tests/load_functions/relimport/function.json
+++ b/tests/load_functions/relimport/function.json
@@ -9,7 +9,7 @@
       "name": "req"
     },
     {
-      "type": "string",
+      "type": "http",
       "direction": "out",
       "name": "$return"
     }

--- a/tests/load_functions/simple/function.json
+++ b/tests/load_functions/simple/function.json
@@ -9,7 +9,7 @@
       "name": "req"
     },
     {
-      "type": "string",
+      "type": "http",
       "direction": "out",
       "name": "$return"
     }

--- a/tests/load_functions/subdir/function.json
+++ b/tests/load_functions/subdir/function.json
@@ -9,7 +9,7 @@
       "name": "req"
     },
     {
-      "type": "string",
+      "type": "http",
       "direction": "out",
       "name": "$return"
     }

--- a/tests/test_broken_functions.py
+++ b/tests/test_broken_functions.py
@@ -211,8 +211,8 @@ class TestMockHost(testutils.AsyncTestCase):
             self.assertRegex(
                 r.response.result.exception.message,
                 r'.*cannot load the invalid_out_anno function'
-                r'.*type of ret binding .* "bytes" '
-                r'does not match its Python annotation "float"')
+                r'.*type of ret binding .* "http" '
+                r'does not match its Python annotation "HttpRequest"')
 
     async def test_load_broken__invalid_in_anno(self):
         async with testutils.start_mockhost(

--- a/tests/test_http_functions.py
+++ b/tests/test_http_functions.py
@@ -13,6 +13,12 @@ class TestHttpFunctions(testutils.WebHostTestCase):
         self.assertEqual(r.text, 'Hello World!')
         self.assertTrue(r.headers['content-type'].startswith('text/plain'))
 
+    def test_return_out(self):
+        r = self.webhost.request('GET', 'return_out')
+        self.assertEqual(r.status_code, 201)
+        self.assertEqual(r.text, 'hello')
+        self.assertTrue(r.headers['content-type'].startswith('text/plain'))
+
     def test_return_bytes(self):
         r = self.webhost.request('GET', 'return_bytes')
         self.assertEqual(r.status_code, 500)

--- a/tests/test_mock_http_functions.py
+++ b/tests/test_mock_http_functions.py
@@ -54,31 +54,6 @@ class TestMockHost(testutils.AsyncTestCase):
 
             self.assertEqual(r.response.return_value.string, 'OK-async')
 
-    async def test_call_function_out_int_param(self):
-        async with testutils.start_mockhost() as host:
-            await host.load_function('return_out')
-
-            invoke_id, r = await host.invoke_function(
-                'return_out', [
-                    protos.ParameterBinding(
-                        name='req',
-                        data=protos.TypedData(
-                            http=protos.RpcHttp(
-                                method='GET')))
-                ])
-
-            self.assertEqual(r.response.result.status,
-                             protos.StatusResult.Success)
-
-            self.assertEqual(r.response.return_value.string, 'wat')
-
-            self.assertEqual(
-                list(r.response.output_data), [
-                    protos.ParameterBinding(
-                        name='foo',
-                        data=protos.TypedData(int=42))
-                ])
-
     async def test_handles_unsupported_messages_gracefully(self):
         async with testutils.start_mockhost() as host:
             # Intentionally send a message to worker that isn't

--- a/tests/test_mock_timer_functions.py
+++ b/tests/test_mock_timer_functions.py
@@ -32,7 +32,7 @@ class TestTimerFunctions(testutils.AsyncTestCase):
                     list(r.response.output_data), [
                         protos.ParameterBinding(
                             name='pastdue',
-                            data=protos.TypedData(int=int(due)))
+                            data=protos.TypedData(string=str(due)))
                     ])
 
             await call_and_check(True)

--- a/tests/timer_functions/return_pastdue/function.json
+++ b/tests/timer_functions/return_pastdue/function.json
@@ -12,7 +12,7 @@
     {
       "direction": "out",
       "name": "pastdue",
-      "type": "int"
+      "type": "http"
     }
   ]
 }

--- a/tests/timer_functions/return_pastdue/main.py
+++ b/tests/timer_functions/return_pastdue/main.py
@@ -1,5 +1,5 @@
 import azure.functions as azf
 
 
-def main(timer: azf.TimerRequest, pastdue: azf.Out[int]):
-    pastdue.set(timer.past_due)
+def main(timer: azf.TimerRequest, pastdue: azf.Out[str]):
+    pastdue.set(str(timer.past_due))


### PR DESCRIPTION
* Group type decoder, encoder, and validator functions in simple
  "Converter" classes.

* Drop support for "string", "int", "bytes", "double", and "json"
  binding types.  They were never supported directly by Azure
  Functions and were added by mistake.

* Add an "Out[HtttResponse]" test.