### PR TITLE
Initial support for Blob binding

### DIFF
--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -1,2 +1,2 @@
-from ._abc import HttpRequest, TimerRequest, Context, Out  # NoQA
+from ._abc import HttpRequest, TimerRequest, InputStream, Context, Out  # NoQA
 from ._http import HttpResponse  # NoQA

--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -1,4 +1,5 @@
 import abc
+import io
 import typing
 
 
@@ -87,4 +88,11 @@ class TimerRequest(abc.ABC):
     @property
     @abc.abstractmethod
     def past_due(self) -> bool:
+        pass
+
+
+class InputStream(io.BufferedIOBase, abc.ABC):
+
+    @abc.abstractmethod
+    def read(self, size=-1) -> bytes:
         pass

--- a/azure/worker/testutils.py
+++ b/azure/worker/testutils.py
@@ -440,8 +440,13 @@ def start_webhost(*, script_dir=None):
     else:
         script_root = FUNCS_PATH
 
+    if os.environ.get('PYAZURE_WEBHOST_DEBUG'):
+        stdout = sys.stdout
+    else:
+        stdout = subprocess.DEVNULL
+
     port = _find_open_port()
-    proc = popen_webhost(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    proc = popen_webhost(stdout=stdout, stderr=subprocess.STDOUT,
                          script_root=script_root, port=port)
 
     addr = f'http://127.0.0.1:{port}'

--- a/azure/worker/type_impl.py
+++ b/azure/worker/type_impl.py
@@ -2,6 +2,7 @@
 
 import enum
 import json
+import io
 import types
 import typing
 
@@ -101,3 +102,20 @@ class TimerRequest(azf_abc.TimerRequest):
     @property
     def past_due(self):
         return self.__past_due
+
+
+class InputStream(azf_abc.InputStream):
+    def __init__(self, *, data: bytes) -> None:
+        self._io = io.BytesIO(data)
+
+    def read(self, size=-1) -> bytes:
+        return self._io.read(size)
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return False

--- a/azure/worker/type_meta.py
+++ b/azure/worker/type_meta.py
@@ -8,6 +8,8 @@ from . import protos
 class Binding(str, enum.Enum):
     """Supported binding types."""
 
+    blob = 'blob'
+    blobTrigger = 'blobTrigger'
     http = 'http'
     httpTrigger = 'httpTrigger'
     timerTrigger = 'timerTrigger'

--- a/tests/blob_functions/get_blob_bytes/function.json
+++ b/tests/blob_functions/get_blob_bytes/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-bytes.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/get_blob_bytes/main.py
+++ b/tests/blob_functions/get_blob_bytes/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return file.read().decode('utf-8')

--- a/tests/blob_functions/get_blob_filelike/function.json
+++ b/tests/blob_functions/get_blob_filelike/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-filelike.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/get_blob_filelike/main.py
+++ b/tests/blob_functions/get_blob_filelike/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return file.read().decode('utf-8')

--- a/tests/blob_functions/get_blob_return/function.json
+++ b/tests/blob_functions/get_blob_return/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-return.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/get_blob_return/main.py
+++ b/tests/blob_functions/get_blob_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return file.read().decode('utf-8')

--- a/tests/blob_functions/get_blob_str/function.json
+++ b/tests/blob_functions/get_blob_str/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-str.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/get_blob_str/main.py
+++ b/tests/blob_functions/get_blob_str/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return file.read().decode('utf-8')

--- a/tests/blob_functions/host.json
+++ b/tests/blob_functions/host.json
@@ -1,0 +1,32 @@
+{
+    "http": {
+        "routePrefix": "api",
+        "maxConcurrentRequests": 5,
+        "maxOutstandingRequests": 30
+    },
+    "logger": {
+        "defaultLevel": "Trace",
+        "categoryLevels": {
+            "Worker": "Trace"
+        }
+    },
+    "queues": {
+        "visibilityTimeout": "00:00:10"
+    },
+    "swagger": {
+        "enabled": true
+    },
+    "eventHub": {
+        "maxBatchSize": 1000,
+        "prefetchCount": 1000,
+        "batchCheckpointFrequency": 1
+    },
+    "healthMonitor": {
+        "enabled": true,
+        "healthCheckInterval": "00:00:10",
+        "healthCheckWindow": "00:02:00",
+        "healthCheckThreshold": 6,
+        "counterThreshold": 0.80
+    },
+    "functionTimeout": "00:05:00",
+}

--- a/tests/blob_functions/ping/README.md
+++ b/tests/blob_functions/ping/README.md
@@ -1,0 +1,2 @@
+This function is used to check the host availability in tests.
+Please do not remove.

--- a/tests/blob_functions/ping/function.json
+++ b/tests/blob_functions/ping/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    }
+  ]
+}

--- a/tests/blob_functions/ping/main.py
+++ b/tests/blob_functions/ping/main.py
@@ -1,0 +1,2 @@
+def main(req):
+    return 'pong'

--- a/tests/blob_functions/put_blob_bytes/function.json
+++ b/tests/blob_functions/put_blob_bytes/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-bytes.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/put_blob_bytes/main.py
+++ b/tests/blob_functions/put_blob_bytes/main.py
@@ -1,0 +1,6 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.Out[str]) -> str:
+    file.set(req.get_body())
+    return 'OK'

--- a/tests/blob_functions/put_blob_filelike/function.json
+++ b/tests/blob_functions/put_blob_filelike/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-filelike.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/put_blob_filelike/main.py
+++ b/tests/blob_functions/put_blob_filelike/main.py
@@ -1,0 +1,8 @@
+import io
+
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.Out[str]) -> str:
+    file.set(io.StringIO('filelike'))
+    return 'OK'

--- a/tests/blob_functions/put_blob_return/function.json
+++ b/tests/blob_functions/put_blob_return/function.json
@@ -1,0 +1,19 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "$return",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-return.txt"
+    }
+  ]
+}

--- a/tests/blob_functions/put_blob_return/main.py
+++ b/tests/blob_functions/put_blob_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest) -> str:
+    return 'FROM RETURN'

--- a/tests/blob_functions/put_blob_str/function.json
+++ b/tests/blob_functions/put_blob_str/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-str.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/put_blob_str/main.py
+++ b/tests/blob_functions/put_blob_str/main.py
@@ -1,0 +1,6 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.Out[str]) -> str:
+    file.set(req.get_body())
+    return 'OK'

--- a/tests/test_blob_functions.py
+++ b/tests/test_blob_functions.py
@@ -1,0 +1,44 @@
+from azure.worker import testutils
+
+
+class TestBlobFunctions(testutils.WebHostTestCase):
+
+    @classmethod
+    def get_script_dir(cls):
+        return 'blob_functions'
+
+    def test_blob_io_str(self):
+        r = self.webhost.request('POST', 'put_blob_str', data='test-data')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'OK')
+
+        r = self.webhost.request('GET', 'get_blob_str', params={'file': ''})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'test-data')
+
+    def test_blob_io_bytes(self):
+        r = self.webhost.request('POST', 'put_blob_bytes',
+                                 data='test-dată'.encode('utf-8'))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'OK')
+
+        r = self.webhost.request('POST', 'get_blob_bytes')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'test-dată')
+
+    def test_blob_io_filelike(self):
+        r = self.webhost.request('POST', 'put_blob_filelike')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'OK')
+
+        r = self.webhost.request('POST', 'get_blob_filelike')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'filelike')
+
+    def test_blob_io_return(self):
+        r = self.webhost.request('POST', 'put_blob_return')
+        self.assertEqual(r.status_code, 200)
+
+        r = self.webhost.request('POST', 'get_blob_return')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'FROM RETURN')


### PR DESCRIPTION
Input bindings are always passed as an `InputStream` object which
implements `BufferedIOBase` and is a read-only non-seekable stream.

Output parameters can be strings, bytes, or file-like objects.