### PR TITLE
Initial support for Queue bindings

### DIFF
--- a/azure/functions/__init__.py
+++ b/azure/functions/__init__.py
@@ -1,2 +1,3 @@
 from ._abc import HttpRequest, TimerRequest, InputStream, Context, Out  # NoQA
 from ._http import HttpResponse  # NoQA
+from ._queue import QueueMessage  # NoQA

--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -1,4 +1,5 @@
 import abc
+import datetime
 import io
 import typing
 
@@ -95,4 +96,45 @@ class InputStream(io.BufferedIOBase, abc.ABC):
 
     @abc.abstractmethod
     def read(self, size=-1) -> bytes:
+        pass
+
+
+class QueueMessage(abc.ABC):
+
+    @property
+    @abc.abstractmethod
+    def id(self) -> typing.Optional[str]:
+        pass
+
+    @abc.abstractmethod
+    def get_body(self) -> typing.Union[str, bytes]:
+        pass
+
+    @abc.abstractmethod
+    def get_json(self) -> typing.Any:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def dequeue_count(self) -> typing.Optional[int]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def expiration_time(self) -> typing.Optional[datetime.datetime]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def insertion_time(self) -> typing.Optional[datetime.datetime]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def next_visible_time(self) -> typing.Optional[datetime.datetime]:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def pop_receipt(self) -> typing.Optional[str]:
         pass

--- a/azure/functions/_queue.py
+++ b/azure/functions/_queue.py
@@ -1,0 +1,66 @@
+import datetime
+import json
+import typing
+
+from . import _abc
+
+
+class QueueMessage(_abc.QueueMessage):
+    """An HTTP response object."""
+
+    def __init__(self, *,
+                 id: typing.Optional[str]=None,
+                 body: typing.Optional[typing.Union[str, bytes]]=None,
+                 pop_receipt: typing.Optional[str]=None) -> None:
+        self.__id = id
+        self.__body = b''
+        self.__pop_receipt = pop_receipt
+
+        if body is not None:
+            self.__set_body(body)
+
+    @property
+    def id(self) -> typing.Optional[str]:
+        return self.__id
+
+    @property
+    def dequeue_count(self) -> typing.Optional[int]:
+        return None
+
+    @property
+    def expiration_time(self) -> typing.Optional[datetime.datetime]:
+        return None
+
+    @property
+    def insertion_time(self) -> typing.Optional[datetime.datetime]:
+        return None
+
+    @property
+    def next_visible_time(self) -> typing.Optional[datetime.datetime]:
+        return None
+
+    @property
+    def pop_receipt(self) -> typing.Optional[str]:
+        return self.__pop_receipt
+
+    def __set_body(self, body):
+        if isinstance(body, str):
+            body = body.encode('utf-8')
+
+        if not isinstance(body, (bytes, bytearray)):
+            raise TypeError(
+                f'reponse is expected to be either of '
+                f'str, bytes, or bytearray, got {type(body).__name__}')
+
+        self.__body = bytes(body)
+
+    def get_body(self) -> bytes:
+        return self.__body
+
+    def get_json(self) -> typing.Any:
+        return json.loads(self.__body)
+
+    def __repr__(self) -> str:
+        return (
+            f'<azure.QueueMessage id={self.id} at 0x{id(self):0x}>'
+        )

--- a/azure/worker/dispatcher.py
+++ b/azure/worker/dispatcher.py
@@ -236,8 +236,12 @@ class Dispatcher(metaclass=DispatcherMeta):
             params = {}
             for pb in invoc_request.input_data:
                 pb_type = fi.input_types[pb.name]
+                if pb_type.is_trigger():
+                    trigger_metadata = invoc_request.trigger_metadata
+                else:
+                    trigger_metadata = None
                 params[pb.name] = type_meta.from_incoming_proto(
-                    pb_type, pb.data)
+                    pb_type, pb.data, trigger_metadata)
 
             if fi.requires_context:
                 params['context'] = type_impl.Context(

--- a/azure/worker/type_impl.py
+++ b/azure/worker/type_impl.py
@@ -8,6 +8,7 @@ import typing
 
 from azure.functions import _abc as azf_abc
 from azure.functions import _http as azf_http
+from azure.functions import _queue as azf_queue
 
 
 class TypedDataKind(enum.Enum):
@@ -119,3 +120,45 @@ class InputStream(azf_abc.InputStream):
 
     def writable(self) -> bool:
         return False
+
+
+class QueueMessage(azf_queue.QueueMessage):
+    """An HTTP response object."""
+
+    def __init__(self, *,
+                 id=None, body=None,
+                 dequeue_count=None,
+                 expiration_time=None,
+                 insertion_time=None,
+                 next_visible_time=None,
+                 pop_receipt=None):
+        super().__init__(id=id, body=body, pop_receipt=pop_receipt)
+        self.__dequeue_count = dequeue_count
+        self.__expiration_time = expiration_time
+        self.__insertion_time = insertion_time
+        self.__next_visible_time = next_visible_time
+
+    @property
+    def dequeue_count(self):
+        return self.__dequeue_count
+
+    @property
+    def expiration_time(self):
+        return self.__expiration_time
+
+    @property
+    def insertion_time(self):
+        return self.__insertion_time
+
+    @property
+    def next_visible_time(self):
+        return self.__next_visible_time
+
+    def __repr__(self) -> str:
+        return (
+            f'<azure.QueueMessage id={self.id} '
+            f'dequeue_count={self.dequeue_count} '
+            f'insertion_time={self.insertion_time} '
+            f'expiration_time={self.expiration_time} '
+            f'at 0x{id(self):0x}>'
+        )

--- a/tests/queue_functions/get_queue_blob/function.json
+++ b/tests/queue_functions/get_queue_blob/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-queue-blob.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/queue_functions/get_queue_blob/main.py
+++ b/tests/queue_functions/get_queue_blob/main.py
@@ -1,0 +1,9 @@
+import json
+
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return json.dumps({
+        'queue': json.loads(file.read().decode('utf-8'))
+    })

--- a/tests/queue_functions/get_queue_blob_message_return/function.json
+++ b/tests/queue_functions/get_queue_blob_message_return/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-queue-blob-message-return.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/queue_functions/get_queue_blob_message_return/main.py
+++ b/tests/queue_functions/get_queue_blob_message_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return file.read().decode('utf-8')

--- a/tests/queue_functions/get_queue_blob_return/function.json
+++ b/tests/queue_functions/get_queue_blob_return/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-queue-blob-return.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/queue_functions/get_queue_blob_return/main.py
+++ b/tests/queue_functions/get_queue_blob_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return file.read().decode('utf-8')

--- a/tests/queue_functions/host.json
+++ b/tests/queue_functions/host.json
@@ -1,0 +1,32 @@
+{
+    "http": {
+        "routePrefix": "api",
+        "maxConcurrentRequests": 5,
+        "maxOutstandingRequests": 30
+    },
+    "logger": {
+        "defaultLevel": "Trace",
+        "categoryLevels": {
+            "Worker": "Trace"
+        }
+    },
+    "queues": {
+        "visibilityTimeout": "00:00:10"
+    },
+    "swagger": {
+        "enabled": true
+    },
+    "eventHub": {
+        "maxBatchSize": 1000,
+        "prefetchCount": 1000,
+        "batchCheckpointFrequency": 1
+    },
+    "healthMonitor": {
+        "enabled": true,
+        "healthCheckInterval": "00:00:10",
+        "healthCheckWindow": "00:02:00",
+        "healthCheckThreshold": 6,
+        "counterThreshold": 0.80
+    },
+    "functionTimeout": "00:05:00",
+}

--- a/tests/queue_functions/ping/README.md
+++ b/tests/queue_functions/ping/README.md
@@ -1,0 +1,2 @@
+This function is used to check the host availability in tests.
+Please do not remove.

--- a/tests/queue_functions/ping/function.json
+++ b/tests/queue_functions/ping/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    }
+  ]
+}

--- a/tests/queue_functions/ping/main.py
+++ b/tests/queue_functions/ping/main.py
@@ -1,0 +1,2 @@
+def main(req):
+    return 'pong'

--- a/tests/queue_functions/put_queue/function.json
+++ b/tests/queue_functions/put_queue/function.json
@@ -1,0 +1,25 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "direction": "out",
+      "name": "msg",
+      "queueName": "testqueue",
+      "connection": "AzureWebJobsStorage",
+      "type": "queue"
+    },
+    {
+      "direction": "out",
+      "name": "$return",
+      "type": "http"
+    }
+  ]
+}

--- a/tests/queue_functions/put_queue/main.py
+++ b/tests/queue_functions/put_queue/main.py
@@ -1,0 +1,7 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, msg: azf.Out[str]):
+    msg.set(req.get_body())
+
+    return 'OK'

--- a/tests/queue_functions/put_queue_message_return/function.json
+++ b/tests/queue_functions/put_queue_message_return/function.json
@@ -1,0 +1,20 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "direction": "out",
+      "name": "$return",
+      "queueName": "testqueue-message-return",
+      "connection": "AzureWebJobsStorage",
+      "type": "queue"
+    }
+  ]
+}

--- a/tests/queue_functions/put_queue_message_return/main.py
+++ b/tests/queue_functions/put_queue_message_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest) -> bytes:
+    return azf.QueueMessage(body=req.get_body())

--- a/tests/queue_functions/put_queue_return/function.json
+++ b/tests/queue_functions/put_queue_return/function.json
@@ -1,0 +1,20 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "direction": "out",
+      "name": "$return",
+      "queueName": "testqueue-return",
+      "connection": "AzureWebJobsStorage",
+      "type": "queue"
+    }
+  ]
+}

--- a/tests/queue_functions/put_queue_return/main.py
+++ b/tests/queue_functions/put_queue_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest) -> bytes:
+    return req.get_body()

--- a/tests/queue_functions/queue_trigger/function.json
+++ b/tests/queue_functions/queue_trigger/function.json
@@ -1,0 +1,22 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "msg",
+      "queueName": "testqueue",
+      "connection": "AzureWebJobsStorage",
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "$return",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-queue-blob.txt"
+    }
+  ]
+}

--- a/tests/queue_functions/queue_trigger/main.py
+++ b/tests/queue_functions/queue_trigger/main.py
@@ -1,0 +1,20 @@
+import json
+
+import azure.functions as azf
+
+
+def main(msg: azf.QueueMessage) -> str:
+    result = json.dumps({
+        'id': msg.id,
+        'body': msg.get_body().decode('utf-8'),
+        'expiration_time': (msg.expiration_time.isoformat()
+                            if msg.expiration_time else None),
+        'insertion_time': (msg.insertion_time.isoformat()
+                           if msg.insertion_time else None),
+        'next_visible_time': (msg.next_visible_time.isoformat()
+                              if msg.next_visible_time else None),
+        'pop_receipt': msg.pop_receipt,
+        'dequeue_count': msg.dequeue_count
+    })
+
+    return result

--- a/tests/queue_functions/queue_trigger_message_return/function.json
+++ b/tests/queue_functions/queue_trigger_message_return/function.json
@@ -1,0 +1,22 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "msg",
+      "queueName": "testqueue-message-return",
+      "connection": "AzureWebJobsStorage",
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "$return",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-queue-blob-message-return.txt"
+    }
+  ]
+}

--- a/tests/queue_functions/queue_trigger_message_return/main.py
+++ b/tests/queue_functions/queue_trigger_message_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(msg: azf.QueueMessage) -> bytes:
+    return msg.get_body()

--- a/tests/queue_functions/queue_trigger_return/function.json
+++ b/tests/queue_functions/queue_trigger_return/function.json
@@ -1,0 +1,22 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "queueTrigger",
+      "direction": "in",
+      "name": "msg",
+      "queueName": "testqueue-return",
+      "connection": "AzureWebJobsStorage",
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "$return",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-queue-blob-return.txt"
+    }
+  ]
+}

--- a/tests/queue_functions/queue_trigger_return/main.py
+++ b/tests/queue_functions/queue_trigger_return/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(msg: azf.QueueMessage) -> bytes:
+    return msg.get_body()

--- a/tests/test_blob_functions.py
+++ b/tests/test_blob_functions.py
@@ -12,7 +12,7 @@ class TestBlobFunctions(testutils.WebHostTestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'OK')
 
-        r = self.webhost.request('GET', 'get_blob_str', params={'file': ''})
+        r = self.webhost.request('GET', 'get_blob_str')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'test-data')
 

--- a/tests/test_queue_functions.py
+++ b/tests/test_queue_functions.py
@@ -1,0 +1,55 @@
+import time
+
+from azure.worker import testutils
+
+
+class TestQueueFunctions(testutils.WebHostTestCase):
+
+    @classmethod
+    def get_script_dir(cls):
+        return 'queue_functions'
+
+    def test_queue_basic(self):
+        r = self.webhost.request('POST', 'put_queue',
+                                 data='test-message')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'OK')
+
+        # wait for queue_trigger to process the queue item
+        time.sleep(1)
+
+        r = self.webhost.request('GET', 'get_queue_blob')
+        self.assertEqual(r.status_code, 200)
+        msg_info = r.json()
+
+        self.assertIn('queue', msg_info)
+        msg = msg_info['queue']
+
+        self.assertEqual(msg['body'], 'test-message')
+        for attr in {'id', 'expiration_time', 'insertion_time',
+                     'next_visible_time', 'pop_receipt', 'dequeue_count'}:
+            self.assertIsNotNone(msg.get(attr))
+
+    def test_queue_return(self):
+        r = self.webhost.request('POST', 'put_queue_return',
+                                 data='test-message-return')
+        self.assertEqual(r.status_code, 200)
+
+        # wait for queue_trigger to process the queue item
+        time.sleep(1)
+
+        r = self.webhost.request('GET', 'get_queue_blob_return')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'test-message-return')
+
+    def test_queue_message_object_return(self):
+        r = self.webhost.request('POST', 'put_queue_message_return',
+                                 data='test-message-object-return')
+        self.assertEqual(r.status_code, 200)
+
+        # wait for queue_trigger to process the queue item
+        time.sleep(1)
+
+        r = self.webhost.request('GET', 'get_queue_blob_message_return')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'test-message-object-return')


### PR DESCRIPTION
Trigger bindings are passwed as a `QueueMessage` object, which can also
be returned along with `str` or `bytes`.