### PR TITLE
Pass Python type to type converters.

### DIFF
--- a/azure/worker/bindings/blob.py
+++ b/azure/worker/bindings/blob.py
@@ -35,7 +35,8 @@ class BlobConverter(meta.InConverter,
                 callable(getattr(pytype, 'read', None))))
 
     @classmethod
-    def to_proto(cls, obj: typing.Any) -> protos.TypedData:
+    def to_proto(cls, obj: typing.Any, *,
+                 pytype: typing.Optional[type]) -> protos.TypedData:
         if callable(getattr(obj, 'read', None)):
             # file-like object
             obj = obj.read()
@@ -50,7 +51,8 @@ class BlobConverter(meta.InConverter,
             raise NotImplementedError
 
     @classmethod
-    def from_proto(cls, data: protos.TypedData,
+    def from_proto(cls, data: protos.TypedData, *,
+                   pytype: typing.Optional[type],
                    trigger_metadata) -> typing.Any:
         data_type = data.WhichOneof('data')
         if data_type == 'string':

--- a/azure/worker/bindings/http.py
+++ b/azure/worker/bindings/http.py
@@ -72,7 +72,8 @@ class HttpResponseConverter(meta.OutConverter, binding='http'):
         return issubclass(pytype, (azf_abc.HttpResponse, str))
 
     @classmethod
-    def to_proto(cls, obj: typing.Any) -> protos.TypedData:
+    def to_proto(cls, obj: typing.Any, *,
+                 pytype: typing.Optional[type]) -> protos.TypedData:
         if isinstance(obj, str):
             return protos.TypedData(string=obj)
 
@@ -110,7 +111,8 @@ class HttpRequestConverter(meta.InConverter,
         return issubclass(pytype, azf_abc.HttpRequest)
 
     @classmethod
-    def from_proto(cls, data: protos.TypedData,
+    def from_proto(cls, data: protos.TypedData, *,
+                   pytype: typing.Optional[type],
                    trigger_metadata) -> typing.Any:
         if data.WhichOneof('data') != 'http':
             raise NotImplementedError

--- a/azure/worker/bindings/queue.py
+++ b/azure/worker/bindings/queue.py
@@ -59,8 +59,9 @@ class QueueMessageInConverter(meta.InConverter,
         return issubclass(pytype, azf_abc.QueueMessage)
 
     @classmethod
-    def from_proto(cls, data: protos.TypedData,
-                   trigger_metadata) -> azf_abc.QueueMessage:
+    def from_proto(cls, data: protos.TypedData, *,
+                   pytype: typing.Optional[type],
+                   trigger_metadata) -> typing.Any:
         data_type = data.WhichOneof('data')
 
         if data_type == 'string':
@@ -117,7 +118,8 @@ class QueueMessageOutConverter(meta.OutConverter, binding='queue'):
         return issubclass(pytype, (azf_abc.QueueMessage, str, bytes))
 
     @classmethod
-    def to_proto(cls, obj: typing.Any) -> protos.TypedData:
+    def to_proto(cls, obj: typing.Any, *,
+                 pytype: typing.Optional[type]) -> protos.TypedData:
         if isinstance(obj, str):
             return protos.TypedData(string=obj)
 

--- a/azure/worker/bindings/timer.py
+++ b/azure/worker/bindings/timer.py
@@ -25,7 +25,8 @@ class TimerRequestConverter(meta.InConverter,
         return issubclass(pytype, azf_abc.TimerRequest)
 
     @classmethod
-    def from_proto(cls, data: protos.TypedData,
+    def from_proto(cls, data: protos.TypedData, *,
+                   pytype: typing.Optional[type],
                    trigger_metadata) -> typing.Any:
         if data.WhichOneof('data') != 'json':
             raise NotImplementedError


### PR DESCRIPTION
This allows to implement custom type encoding/decoding logic
depending on parameter annotatition type.

Closes issue #67.