### PR TITLE
Raise an error if function w/o a $return binding returns a non-None.

### DIFF
--- a/azure/worker/dispatcher.py
+++ b/azure/worker/dispatcher.py
@@ -260,6 +260,11 @@ class Dispatcher(metaclass=DispatcherMeta):
                     self._sync_call_tp,
                     self.__run_sync_func, invocation_id, fi.func, args)
 
+            if call_result is not None and not fi.has_return:
+                raise RuntimeError(
+                    f'function {fi.name!r} without a $return binding '
+                    f'returned a non-None value')
+
             output_data = []
             if fi.output_types:
                 for out_name, out_type_info in fi.output_types.items():

--- a/azure/worker/functions.py
+++ b/azure/worker/functions.py
@@ -21,6 +21,7 @@ class FunctionInfo(typing.NamedTuple):
     directory: str
     requires_context: bool
     is_async: bool
+    has_return: bool
 
     input_types: typing.Mapping[str, ParamTypeInfo]
     output_types: typing.Mapping[str, ParamTypeInfo]
@@ -61,6 +62,7 @@ class Registry:
         return_pytype: typing.Optional[type] = None
 
         requires_context = False
+        has_return = False
 
         bound_params = {}
         for name, desc in metadata.bindings.items():
@@ -82,6 +84,8 @@ class Registry:
                     raise FunctionLoadError(
                         func_name,
                         f'unknown type for $return binding: "{desc.type}"')
+
+                has_return = True
             else:
                 bound_params[name] = desc
 
@@ -199,6 +203,7 @@ class Registry:
             directory=metadata.directory,
             requires_context=requires_context,
             is_async=inspect.iscoroutinefunction(func),
+            has_return=has_return,
             input_types=input_types,
             output_types=output_types,
             return_type=return_type)

--- a/tests/blob_functions/ping/main.py
+++ b/tests/blob_functions/ping/main.py
@@ -1,2 +1,2 @@
 def main(req):
-    return 'pong'
+    return

--- a/tests/http_functions/no_return_returns/function.json
+++ b/tests/http_functions/no_return_returns/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    }
+  ]
+}

--- a/tests/http_functions/no_return_returns/main.py
+++ b/tests/http_functions/no_return_returns/main.py
@@ -1,0 +1,2 @@
+def main(req):
+    return 'ABC'

--- a/tests/http_functions/ping/main.py
+++ b/tests/http_functions/ping/main.py
@@ -1,2 +1,2 @@
 def main(req):
-    return 'pong'
+    return

--- a/tests/load_functions/ping/main.py
+++ b/tests/load_functions/ping/main.py
@@ -1,2 +1,2 @@
 def main(req):
-    return 'pong'
+    return

--- a/tests/queue_functions/ping/main.py
+++ b/tests/queue_functions/ping/main.py
@@ -1,2 +1,2 @@
 def main(req):
-    return 'pong'
+    return

--- a/tests/test_http_functions.py
+++ b/tests/test_http_functions.py
@@ -51,6 +51,13 @@ class TestHttpFunctions(testutils.WebHostTestCase):
         r = self.webhost.request('GET', 'no_return')
         self.assertEqual(r.status_code, 204)
 
+    def test_no_return_returns(self):
+        r = self.webhost.request('GET', 'no_return_returns')
+        self.assertEqual(r.status_code, 500)
+        self.assertRegex(r.text,
+                         r'.*function .+no_return_returns.+ without a '
+                         r'\$return binding returned a non-None value.*')
+
     def test_async_return_str(self):
         r = self.webhost.request('GET', 'async_return_str')
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
Closes issue #74.