### PR TITLE
Add support for BlobTrigger metadata

### DIFF
--- a/azure/worker/bindings/blob.py
+++ b/azure/worker/bindings/blob.py
@@ -8,8 +8,26 @@ from .. import protos
 
 
 class InputStream(azf_abc.InputStream):
-    def __init__(self, *, data: bytes) -> None:
+    def __init__(self, *, data: bytes,
+                 name: typing.Optional[str]=None,
+                 uri: typing.Optional[str]=None,
+                 length: typing.Optional[int]=None) -> None:
         self._io = io.BytesIO(data)
+        self._name = name
+        self._length = length
+        self._uri = uri
+
+    @property
+    def name(self) -> typing.Optional[str]:
+        return self._name
+
+    @property
+    def length(self) -> typing.Optional[int]:
+        return self._length
+
+    @property
+    def uri(self) -> typing.Optional[str]:
+        return self._uri
 
     def read(self, size=-1) -> bytes:
         return self._io.read(size)
@@ -62,7 +80,28 @@ class BlobConverter(meta.InConverter,
         else:
             raise NotImplementedError
 
-        return InputStream(data=data)
+        if trigger_metadata is None:
+            return InputStream(data=data)
+        else:
+            properties = cls._decode_trigger_metadata_field(
+                trigger_metadata, 'Properties', python_type=dict)
+            if properties:
+                length = properties.get('Length')
+                if length:
+                    length = int(length)
+                else:
+                    length = None
+            else:
+                length = None
+
+            return InputStream(
+                data=data,
+                name=cls._decode_trigger_metadata_field(
+                    trigger_metadata, 'BlobTrigger', python_type=str),
+                length=length,
+                uri=cls._decode_trigger_metadata_field(
+                    trigger_metadata, 'Uri', python_type=str),
+            )
 
 
 class BlobTriggerConverter(BlobConverter,

--- a/azure/worker/bindings/meta.py
+++ b/azure/worker/bindings/meta.py
@@ -67,7 +67,7 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
         pass
 
     @classmethod
-    def _decode_scalar_typed_data(
+    def _decode_typed_data(
             cls, data: typing.Optional[protos.TypedData], *,
             python_type: typing.Union[type, typing.Tuple[type, ...]],
             context: str='data') -> typing.Any:
@@ -77,9 +77,6 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
         data_type = data.WhichOneof('data')
         if data_type == 'json':
             result = json.loads(data.json)
-            if isinstance(result, (list, dict)):
-                raise ValueError(
-                    f'unexpected data structure in expected scalar {context}')
 
         elif data_type == 'string':
             result = data.string
@@ -95,7 +92,7 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
                 f'unsupported type of {context}: {data_type}')
 
         if not isinstance(result, python_type):
-            if isinstance(python_type, tuple):
+            if isinstance(python_type, (tuple, list, dict)):
                 raise ValueError(
                     f'unexpected value type in {context}: '
                     f'{type(result).__name__}, expected one of: '
@@ -121,7 +118,7 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
         if data is None:
             return None
         else:
-            return cls._decode_scalar_typed_data(
+            return cls._decode_typed_data(
                 data, python_type=python_type,
                 context=f'field {field!r} in trigger metadata')
 

--- a/azure/worker/testutils.py
+++ b/azure/worker/testutils.py
@@ -108,8 +108,9 @@ class WebHostTestCase(unittest.TestCase, metaclass=WebHostTestCaseMeta):
         cls.webhost.close()
         cls.webhost = None
 
-        cls.host_stdout.close()
-        cls.host_stdout = None
+        if cls.host_stdout is not None:
+            cls.host_stdout.close()
+            cls.host_stdout = None
 
     def _run_test(self, test, *args, **kwargs):
         if self.host_stdout is None:

--- a/tests/blob_functions/blob_trigger/function.json
+++ b/tests/blob_functions/blob_trigger/function.json
@@ -1,0 +1,20 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "blobTrigger",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-blob-trigger.txt"
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "$return",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-blob-triggered.txt"
+    },
+  ]
+}

--- a/tests/blob_functions/blob_trigger/main.py
+++ b/tests/blob_functions/blob_trigger/main.py
@@ -1,0 +1,11 @@
+import json
+
+import azure.functions as azf
+
+
+def main(file: azf.InputStream) -> str:
+    return json.dumps({
+        'name': file.name,
+        'length': file.length,
+        'content': file.read().decode('utf-8')
+    })

--- a/tests/blob_functions/get_blob_triggered/function.json
+++ b/tests/blob_functions/get_blob_triggered/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-blob-triggered.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/get_blob_triggered/main.py
+++ b/tests/blob_functions/get_blob_triggered/main.py
@@ -1,0 +1,5 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.InputStream) -> str:
+    return file.read().decode('utf-8')

--- a/tests/blob_functions/put_blob_trigger/function.json
+++ b/tests/blob_functions/put_blob_trigger/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "out",
+      "name": "file",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-blob-trigger.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return",
+    }
+  ]
+}

--- a/tests/blob_functions/put_blob_trigger/main.py
+++ b/tests/blob_functions/put_blob_trigger/main.py
@@ -1,0 +1,6 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: azf.Out[str]) -> str:
+    file.set(req.get_body())
+    return 'OK'

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -97,6 +97,7 @@ class TestTriggerMetadataDecoder(unittest.TestCase):
             'int_as_int': protos.TypedData(int=1),
             'string_as_json': protos.TypedData(json='"aaa"'),
             'string_as_string': protos.TypedData(string='aaa'),
+            'dict_as_json': protos.TypedData(json='{"foo":"bar"}')
         }
 
         cases = [
@@ -105,6 +106,7 @@ class TestTriggerMetadataDecoder(unittest.TestCase):
             ('int_as_int', int, 1),
             ('string_as_json', str, 'aaa'),
             ('string_as_string', str, 'aaa'),
+            ('dict_as_json', dict, {'foo': 'bar'}),
         ]
 
         for field, pytype, expected in cases:
@@ -130,8 +132,8 @@ class TestTriggerMetadataDecoder(unittest.TestCase):
             ),
             (
                 'unexpected_json', int, ValueError,
-                "unexpected data structure in expected scalar field "
-                "'unexpected_json' in trigger metadata"
+                "cannot convert value of field 'unexpected_json' in "
+                "trigger metadata into int"
             ),
             (
                 'unexpected_data', int, ValueError,


### PR DESCRIPTION
When declared as a BlobTrigger, the InputStream now exposes the `name`,
`length` and `uri` properties.