### PR TITLE
changed how python worker is started

### DIFF
--- a/azure/worker/testutils.py
+++ b/azure/worker/testutils.py
@@ -466,7 +466,7 @@ def popen_webhost(*, stdout, stderr, script_root=FUNCS_PATH, port=None):
     extra_env = {
         'AzureWebJobsScriptRoot': str(script_root),
         'workers:config:path': str(worker_path),
-        'workers:python:path': str(worker_path / 'python' / 'worker.py'),
+        'workers:python:path': str(worker_path / 'python' / 'start.sh'),
         'host:logger:consoleLoggingMode': 'always',
     }
 

--- a/python/start.sh
+++ b/python/start.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+set -x
+
+# Directory name for start.sh
+DIR="$(dirname $0)"
+
+# If we're not in a virtual environment, we need to start our host
+if [ -z "$VIRTUAL_ENV"]
+then
+
+# Determining the virtual environment entry point
+if [ -z "$AZURE_FUNCTIONS_VIRTUAL_ENVIRONMENT"]
+then
+    AZURE_FUNCTIONS_VIRTUAL_ENVIRONMENT='../../worker_env/bin/activate'
+fi
+
+echo "activating virtual environment"
+AZFVENV=$DIR
+AZFVENV+='/'
+AZFVENV+=$AZURE_FUNCTIONS_VIRTUAL_ENVIRONMENT
+source $AZFVENV
+fi
+
+echo "starting the python worker"
+python $DIR/worker.py $@

--- a/python/worker.config.json
+++ b/python/worker.config.json
@@ -2,8 +2,8 @@
     "Description":{
         "Language":"python",
         "Extension":".py",
-        "DefaultExecutablePath":"python",
-        "DefaultWorkerPath":"worker.py"
+        "DefaultExecutablePath":"sh",
+        "DefaultWorkerPath":"start.sh"
     },
     "Arguments":[]
 }


### PR DESCRIPTION
This changes the startup to use a bash script.

This means it won't work on Windows (since most folks don't have cygwin/bash installed). We need to address this eventually. It does work with WSL (which is what I tested on).