### PR TITLE
Validate type annotation separately for input and output bindings

### DIFF
--- a/azure/worker/bindings/__init__.py
+++ b/azure/worker/bindings/__init__.py
@@ -1,5 +1,6 @@
 from .context import Context
-from .meta import check_type_annotation
+from .meta import check_input_type_annotation
+from .meta import check_output_type_annotation
 from .meta import is_binding, is_trigger_binding
 from .meta import from_incoming_proto, to_outgoing_proto
 from .out import Out
@@ -15,6 +16,6 @@ from . import timer  # NoQA
 __all__ = (
     'Out', 'Context',
     'is_binding', 'is_trigger_binding',
-    'check_type_annotation',
+    'check_input_type_annotation', 'check_output_type_annotation',
     'from_incoming_proto', 'to_outgoing_proto',
 )

--- a/azure/worker/bindings/blob.py
+++ b/azure/worker/bindings/blob.py
@@ -47,7 +47,11 @@ class BlobConverter(meta.InConverter,
                     binding='blob'):
 
     @classmethod
-    def check_python_type(cls, pytype: type) -> bool:
+    def check_input_type_annotation(cls, pytype: type) -> bool:
+        return issubclass(pytype, azf_abc.InputStream)
+
+    @classmethod
+    def check_output_type_annotation(cls, pytype: type) -> bool:
         return (issubclass(pytype, (str, bytes, bytearray,
                                     azf_abc.InputStream) or
                 callable(getattr(pytype, 'read', None))))

--- a/azure/worker/bindings/http.py
+++ b/azure/worker/bindings/http.py
@@ -68,7 +68,7 @@ class HttpRequest(azf_abc.HttpRequest):
 class HttpResponseConverter(meta.OutConverter, binding='http'):
 
     @classmethod
-    def check_python_type(cls, pytype: type) -> bool:
+    def check_output_type_annotation(cls, pytype: type) -> bool:
         return issubclass(pytype, (azf_abc.HttpResponse, str))
 
     @classmethod
@@ -107,7 +107,7 @@ class HttpRequestConverter(meta.InConverter,
                            binding='httpTrigger', trigger=True):
 
     @classmethod
-    def check_python_type(cls, pytype: type) -> bool:
+    def check_input_type_annotation(cls, pytype: type) -> bool:
         return issubclass(pytype, azf_abc.HttpRequest)
 
     @classmethod

--- a/azure/worker/bindings/queue.py
+++ b/azure/worker/bindings/queue.py
@@ -55,7 +55,7 @@ class QueueMessageInConverter(meta.InConverter,
                               binding='queueTrigger', trigger=True):
 
     @classmethod
-    def check_python_type(cls, pytype: type) -> bool:
+    def check_input_type_annotation(cls, pytype: type) -> bool:
         return issubclass(pytype, azf_abc.QueueMessage)
 
     @classmethod
@@ -114,7 +114,7 @@ class QueueMessageInConverter(meta.InConverter,
 class QueueMessageOutConverter(meta.OutConverter, binding='queue'):
 
     @classmethod
-    def check_python_type(cls, pytype: type) -> bool:
+    def check_output_type_annotation(cls, pytype: type) -> bool:
         return issubclass(pytype, (azf_abc.QueueMessage, str, bytes))
 
     @classmethod

--- a/azure/worker/bindings/timer.py
+++ b/azure/worker/bindings/timer.py
@@ -21,7 +21,7 @@ class TimerRequestConverter(meta.InConverter,
                             binding='timerTrigger', trigger=True):
 
     @classmethod
-    def check_python_type(cls, pytype: type) -> bool:
+    def check_input_type_annotation(cls, pytype: type) -> bool:
         return issubclass(pytype, azf_abc.TimerRequest)
 
     @classmethod

--- a/azure/worker/functions.py
+++ b/azure/worker/functions.py
@@ -157,8 +157,12 @@ class Registry:
                 else:
                     param_py_type = param.annotation
                 if param_py_type:
-                    if not bindings.check_type_annotation(
-                            param_bind_type, param_py_type):
+                    if is_param_out:
+                        checker = bindings.check_output_type_annotation
+                    else:
+                        checker = bindings.check_input_type_annotation
+
+                    if not checker(param_bind_type, param_py_type):
                         raise FunctionLoadError(
                             func_name,
                             f'type of {param.name} binding in function.json '
@@ -186,7 +190,7 @@ class Registry:
                     func_name,
                     f'return annotation should not be azure.functions.Out')
 
-            if not bindings.check_type_annotation(
+            if not bindings.check_output_type_annotation(
                     return_binding_name, return_pytype):
                 raise FunctionLoadError(
                     func_name,


### PR DESCRIPTION
Input and output bindings have different requirements for the type
annotation.  Input bindings are usually passed as a specific
`azure.functions` type, whereas the output type may vary.

This corrects converters that implement both In and Out interfaces.