### PR TITLE
Rename QueueMessage.next_visible_time to time_next_visible

### DIFF
--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -172,7 +172,7 @@ class QueueMessage(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def next_visible_time(self) -> typing.Optional[datetime.datetime]:
+    def time_next_visible(self) -> typing.Optional[datetime.datetime]:
         pass
 
     @property

--- a/azure/functions/_queue.py
+++ b/azure/functions/_queue.py
@@ -50,7 +50,7 @@ class QueueMessage(_abc.QueueMessage):
         return None
 
     @property
-    def next_visible_time(self) -> typing.Optional[datetime.datetime]:
+    def time_next_visible(self) -> typing.Optional[datetime.datetime]:
         """A datetime object with the time the message will be visible next."""
         return None
 

--- a/azure/worker/bindings/queue.py
+++ b/azure/worker/bindings/queue.py
@@ -17,13 +17,13 @@ class QueueMessage(azf_queue.QueueMessage):
                  dequeue_count=None,
                  expiration_time=None,
                  insertion_time=None,
-                 next_visible_time=None,
+                 time_next_visible=None,
                  pop_receipt=None):
         super().__init__(id=id, body=body, pop_receipt=pop_receipt)
         self.__dequeue_count = dequeue_count
         self.__expiration_time = expiration_time
         self.__insertion_time = insertion_time
-        self.__next_visible_time = next_visible_time
+        self.__time_next_visible = time_next_visible
 
     @property
     def dequeue_count(self):
@@ -38,8 +38,8 @@ class QueueMessage(azf_queue.QueueMessage):
         return self.__insertion_time
 
     @property
-    def next_visible_time(self):
-        return self.__next_visible_time
+    def time_next_visible(self):
+        return self.__time_next_visible
 
     def __repr__(self) -> str:
         return (
@@ -88,7 +88,7 @@ class QueueMessageInConverter(meta.InConverter,
                 trigger_metadata, 'ExpirationTime'),
             insertion_time=cls._parse_datetime_metadata(
                 trigger_metadata, 'InsertionTime'),
-            next_visible_time=cls._parse_datetime_metadata(
+            time_next_visible=cls._parse_datetime_metadata(
                 trigger_metadata, 'NextVisibleTime'),
             pop_receipt=cls._decode_trigger_metadata_field(
                 trigger_metadata, 'PopReceipt', python_type=str)

--- a/tests/queue_functions/queue_trigger/main.py
+++ b/tests/queue_functions/queue_trigger/main.py
@@ -11,8 +11,8 @@ def main(msg: azf.QueueMessage) -> str:
                             if msg.expiration_time else None),
         'insertion_time': (msg.insertion_time.isoformat()
                            if msg.insertion_time else None),
-        'next_visible_time': (msg.next_visible_time.isoformat()
-                              if msg.next_visible_time else None),
+        'time_next_visible': (msg.time_next_visible.isoformat()
+                              if msg.time_next_visible else None),
         'pop_receipt': msg.pop_receipt,
         'dequeue_count': msg.dequeue_count
     })

--- a/tests/test_queue_functions.py
+++ b/tests/test_queue_functions.py
@@ -27,7 +27,7 @@ class TestQueueFunctions(testutils.WebHostTestCase):
 
         self.assertEqual(msg['body'], 'test-message')
         for attr in {'id', 'expiration_time', 'insertion_time',
-                     'next_visible_time', 'pop_receipt', 'dequeue_count'}:
+                     'time_next_visible', 'pop_receipt', 'dequeue_count'}:
             self.assertIsNotNone(msg.get(attr))
 
     def test_queue_return(self):


### PR DESCRIPTION
This is to synchronize with the nomenclature in Azure Python SDK

Issue #92.