### PR TITLE
Document InputStream properties

### DIFF
--- a/azure/functions/_abc.py
+++ b/azure/functions/_abc.py
@@ -139,6 +139,24 @@ class InputStream(io.BufferedIOBase, abc.ABC):
         """
         pass
 
+    @property
+    @abc.abstractmethod
+    def name(self) -> typing.Optional[str]:
+        """The name of the blob."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def length(self) -> typing.Optional[int]:
+        """The size of the blob in bytes."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def uri(self) -> typing.Optional[str]:
+        """The blob's primary location URI."""
+        pass
+
 
 class QueueMessage(abc.ABC):
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Programming Model
 =================
 
 An Azure function is implemented as a global Python function ``main()`` in the
-file called ``main.py``. The name of the Python function can be changed by
+file called ``__init__.py``. The name of the Python function can be changed by
 specifying the ``entryPoint`` attribute in ``function.json``, and the name of
 the file can be changed by specifying the ``scriptFile`` attribute in
 ``function.json``.
@@ -33,7 +33,7 @@ Below is an example of a simple function triggerred by an HTTP request.
 .. code-block:: json
 
     {
-      "scriptFile": "main.py",
+      "scriptFile": "__init__.py",
       "disabled": false,
       "bindings": [
         {
@@ -51,7 +51,7 @@ Below is an example of a simple function triggerred by an HTTP request.
     }
 
 
-``main.py``:
+``__init__.py``:
 
 .. code-block:: python
 
@@ -124,7 +124,7 @@ Example
 .. code-block:: json
 
     {
-      "scriptFile": "main.py",
+      "scriptFile": "__init__.py",
       "disabled": false,
       "bindings": [
         {
@@ -142,7 +142,7 @@ Example
     }
 
 
-``main.py``:
+``__init__.py``:
 
 .. code-block:: python
 
@@ -189,7 +189,7 @@ Blob storage trigger example
     }
 
 
-``main.py``:
+``__init__.py``:
 
 
 .. code-block:: python
@@ -232,7 +232,7 @@ Blob storage output example
     }
 
 
-``main.py``:
+``__init__.py``:
 
 
 .. code-block:: python
@@ -272,7 +272,7 @@ Example
 .. code-block:: json
 
     {
-      "scriptFile": "main.py",
+      "scriptFile": "__init__.py",
 
       "bindings": [
         {
@@ -293,7 +293,7 @@ Example
     }
 
 
-``main.py``:
+``__init__.py``:
 
 .. code-block:: python
 
@@ -326,7 +326,7 @@ Example
 .. code-block:: json
 
     {
-      "scriptFile": "main.py",
+      "scriptFile": "__init__.py",
 
       "bindings": [
         {
@@ -346,7 +346,7 @@ Example
     }
 
 
-``main.py``:
+``__init__.py``:
 
 .. code-block:: python
 


### PR DESCRIPTION
While at it, fix the default Python source file name to
`__init__.py`

Issue #94.