### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,7 @@
 [flake8]
 ignore = W503,E402,E731
 exclude =
-    .git, __pycache__, build, dist, .eggs, .github, .local,
-    Samples, azure/functions_worker/protos/, docs/
+    .git, __pycache__, build, dist, .eggs, .github, .local, docs/,
+    Samples, azure/functions_worker/protos/,
+    azure/functions_worker/typing_inspect.py,
+    tests/test_typing_inspect.py

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ ENV/
 
 .testconfig
 .pytest_cache
+tests/*_functions/bin/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
 
     matrix:
         - PYTHON_VERSION: 3.6
-        # - PYTHON_VERSION: 3.7
+        - PYTHON_VERSION: 3.7
 
 for:
 -

--- a/azure/functions_worker/typing_inspect.py
+++ b/azure/functions_worker/typing_inspect.py
@@ -1,0 +1,375 @@
+# Imported from https://github.com/ilevkivskyi/typing_inspect/blob/168fa6f7c5c55f720ce6282727211cf4cf6368f6/typing_inspect.py
+# Author: Ivan Levkivskyi
+# License: MIT
+
+"""Defines experimental API for runtime inspection of types defined
+in the standard "typing" module.
+
+Example usage::
+    from typing_inspect import is_generic_type
+"""
+
+# NOTE: This module must support Python 2.7 in addition to Python 3.x
+
+import sys
+NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
+if NEW_TYPING:
+    import collections.abc
+
+
+if NEW_TYPING:
+    from typing import (
+        Generic, Callable, Union, TypeVar, ClassVar, Tuple, _GenericAlias
+    )
+else:
+    from typing import (
+        Callable, CallableMeta, Union, _Union, TupleMeta, TypeVar,
+        _ClassVar, GenericMeta,
+    )
+
+
+# from mypy_extensions import _TypedDictMeta
+
+
+def _gorg(cls):
+    """This function exists for compatibility with old typing versions."""
+    assert isinstance(cls, GenericMeta)
+    if hasattr(cls, '_gorg'):
+        return cls._gorg
+    while cls.__origin__ is not None:
+        cls = cls.__origin__
+    return cls
+
+
+def is_generic_type(tp):
+    """Test if the given type is a generic type. This includes Generic itself, but
+    excludes special typing constructs such as Union, Tuple, Callable, ClassVar.
+    Examples::
+
+        is_generic_type(int) == False
+        is_generic_type(Union[int, str]) == False
+        is_generic_type(Union[int, T]) == False
+        is_generic_type(ClassVar[List[int]]) == False
+        is_generic_type(Callable[..., T]) == False
+
+        is_generic_type(Generic) == True
+        is_generic_type(Generic[T]) == True
+        is_generic_type(Iterable[int]) == True
+        is_generic_type(Mapping) == True
+        is_generic_type(MutableMapping[T, List[int]]) == True
+        is_generic_type(Sequence[Union[str, bytes]]) == True
+    """
+    if NEW_TYPING:
+        return (isinstance(tp, type) and issubclass(tp, Generic) or
+                isinstance(tp, _GenericAlias) and
+                tp.__origin__ not in (Union, tuple, ClassVar, collections.abc.Callable))
+    return (isinstance(tp, GenericMeta) and not
+            isinstance(tp, (CallableMeta, TupleMeta)))
+
+
+def is_callable_type(tp):
+    """Test if the type is a generic callable type, including subclasses
+    excluding non-generic types and callables.
+    Examples::
+
+        is_callable_type(int) == False
+        is_callable_type(type) == False
+        is_callable_type(Callable) == True
+        is_callable_type(Callable[..., int]) == True
+        is_callable_type(Callable[[int, int], Iterable[str]]) == True
+        class MyClass(Callable[[int], int]):
+            ...
+        is_callable_type(MyClass) == True
+
+    For more general tests use callable(), for more precise test
+    (excluding subclasses) use::
+
+        get_origin(tp) is collections.abc.Callable  # Callable prior to Python 3.7
+    """
+    if NEW_TYPING:
+        return (tp is Callable or isinstance(tp, _GenericAlias) and
+                tp.__origin__ is collections.abc.Callable or
+                isinstance(tp, type) and issubclass(tp, Generic) and
+                issubclass(tp, collections.abc.Callable))
+    return type(tp) is CallableMeta
+
+
+def is_tuple_type(tp):
+    """Test if the type is a generic tuple type, including subclasses excluding
+    non-generic classes.
+    Examples::
+
+        is_tuple_type(int) == False
+        is_tuple_type(tuple) == False
+        is_tuple_type(Tuple) == True
+        is_tuple_type(Tuple[str, int]) == True
+        class MyClass(Tuple[str, int]):
+            ...
+        is_tuple_type(MyClass) == True
+
+    For more general tests use issubclass(..., tuple), for more precise test
+    (excluding subclasses) use::
+
+        get_origin(tp) is tuple  # Tuple prior to Python 3.7
+    """
+    if NEW_TYPING:
+        return (tp is Tuple or isinstance(tp, _GenericAlias) and
+                tp.__origin__ is tuple or
+                isinstance(tp, type) and issubclass(tp, Generic) and
+                issubclass(tp, tuple))
+    return type(tp) is TupleMeta
+
+
+def is_union_type(tp):
+    """Test if the type is a union type. Examples::
+
+        is_union_type(int) == False
+        is_union_type(Union) == True
+        is_union_type(Union[int, int]) == False
+        is_union_type(Union[T, int]) == True
+    """
+    if NEW_TYPING:
+        return (tp is Union or
+                isinstance(tp, _GenericAlias) and tp.__origin__ is Union)
+    return type(tp) is _Union
+
+
+def is_typevar(tp):
+    """Test if the type represents a type variable. Examples::
+
+        is_typevar(int) == False
+        is_typevar(T) == True
+        is_typevar(Union[T, int]) == False
+    """
+
+    return type(tp) is TypeVar
+
+
+def is_classvar(tp):
+    """Test if the type represents a class variable. Examples::
+
+        is_classvar(int) == False
+        is_classvar(ClassVar) == True
+        is_classvar(ClassVar[int]) == True
+        is_classvar(ClassVar[List[T]]) == True
+    """
+    if NEW_TYPING:
+        return (tp is ClassVar or
+                isinstance(tp, _GenericAlias) and tp.__origin__ is ClassVar)
+    return type(tp) is _ClassVar
+
+
+def get_last_origin(tp):
+    """Get the last base of (multiply) subscripted type. Supports generic types,
+    Union, Callable, and Tuple. Returns None for unsupported types.
+    Examples::
+
+        get_last_origin(int) == None
+        get_last_origin(ClassVar[int]) == None
+        get_last_origin(Generic[T]) == Generic
+        get_last_origin(Union[T, int][str]) == Union[T, int]
+        get_last_origin(List[Tuple[T, T]][int]) == List[Tuple[T, T]]
+        get_last_origin(List) == List
+    """
+    if NEW_TYPING:
+        raise ValueError('This function is only supported in Python 3.6,'
+                         ' use get_origin instead')
+    sentinel = object()
+    origin = getattr(tp, '__origin__', sentinel)
+    if origin is sentinel:
+        return None
+    if origin is None:
+        return tp
+    return origin
+
+
+def get_origin(tp):
+    """Get the unsubscripted version of a type. Supports generic types, Union,
+    Callable, and Tuple. Returns None for unsupported types. Examples::
+
+        get_origin(int) == None
+        get_origin(ClassVar[int]) == None
+        get_origin(Generic) == Generic
+        get_origin(Generic[T]) == Generic
+        get_origin(Union[T, int]) == Union
+        get_origin(List[Tuple[T, T]][int]) == list  # List prior to Python 3.7
+    """
+    if NEW_TYPING:
+        if isinstance(tp, _GenericAlias):
+            return tp.__origin__ if tp.__origin__ is not ClassVar else None
+        if tp is Generic:
+            return Generic
+        return None
+    if isinstance(tp, GenericMeta):
+        return _gorg(tp)
+    if is_union_type(tp):
+        return Union
+
+    return None
+
+
+def get_parameters(tp):
+    """Return type parameters of a parameterizable type as a tuple
+    in lexicographic order. Parameterizable types are generic types,
+    unions, tuple types and callable types. Examples::
+
+        get_parameters(int) == ()
+        get_parameters(Generic) == ()
+        get_parameters(Union) == ()
+        get_parameters(List[int]) == ()
+
+        get_parameters(Generic[T]) == (T,)
+        get_parameters(Tuple[List[T], List[S_co]]) == (T, S_co)
+        get_parameters(Union[S_co, Tuple[T, T]][int, U]) == (U,)
+        get_parameters(Mapping[T, Tuple[S_co, T]]) == (T, S_co)
+    """
+    if NEW_TYPING:
+        if (isinstance(tp, _GenericAlias) or
+            isinstance(tp, type) and issubclass(tp, Generic) and
+            tp is not Generic):
+            return tp.__parameters__
+        return ()
+    if (
+        is_generic_type(tp) or is_union_type(tp) or
+        is_callable_type(tp) or is_tuple_type(tp)
+    ):
+        return tp.__parameters__ if tp.__parameters__ is not None else ()
+    return ()
+
+
+def get_last_args(tp):
+    """Get last arguments of (multiply) subscripted type.
+       Parameters for Callable are flattened. Examples::
+
+        get_last_args(int) == ()
+        get_last_args(Union) == ()
+        get_last_args(ClassVar[int]) == (int,)
+        get_last_args(Union[T, int]) == (T, int)
+        get_last_args(Iterable[Tuple[T, S]][int, T]) == (int, T)
+        get_last_args(Callable[[T], int]) == (T, int)
+        get_last_args(Callable[[], int]) == (int,)
+    """
+    if NEW_TYPING:
+        raise ValueError('This function is only supported in Python 3.6,'
+                         ' use get_args instead')
+    if is_classvar(tp):
+        return (tp.__type__,) if tp.__type__ is not None else ()
+    if (
+        is_generic_type(tp) or is_union_type(tp) or
+        is_callable_type(tp) or is_tuple_type(tp)
+    ):
+        return tp.__args__ if tp.__args__ is not None else ()
+    return ()
+
+
+def _eval_args(args):
+    """Internal helper for get_args."""
+    res = []
+    for arg in args:
+        if not isinstance(arg, tuple):
+            res.append(arg)
+        elif is_callable_type(arg[0]):
+            if len(arg) == 2:
+                res.append(Callable[[], arg[1]])
+            elif arg[1] is Ellipsis:
+                res.append(Callable[..., arg[2]])
+            else:
+                res.append(Callable[list(arg[1:-1]), arg[-1]])
+        else:
+            res.append(type(arg[0]).__getitem__(arg[0], _eval_args(arg[1:])))
+    return tuple(res)
+
+
+def get_args(tp, evaluate=None):
+    """Get type arguments with all substitutions performed. For unions,
+    basic simplifications used by Union constructor are performed.
+    On versions prior to 3.7 if `evaluate` is False (default),
+    report result as nested tuple, this matches
+    the internal representation of types. If `evaluate` is True
+    (or if Python version is 3.7 or greater), then all
+    type parameters are applied (this could be time and memory expensive).
+    Examples::
+
+        get_args(int) == ()
+        get_args(Union[int, Union[T, int], str][int]) == (int, str)
+        get_args(Union[int, Tuple[T, int]][str]) == (int, (Tuple, str, int))
+
+        get_args(Union[int, Tuple[T, int]][str], evaluate=True) == \
+                 (int, Tuple[str, int])
+        get_args(Dict[int, Tuple[T, T]][Optional[int]], evaluate=True) == \
+                 (int, Tuple[Optional[int], Optional[int]])
+        get_args(Callable[[], T][int], evaluate=True) == ([], int,)
+    """
+    if NEW_TYPING:
+        if evaluate is not None and not evaluate:
+            raise ValueError('evaluate can only be True in Python 3.7')
+        if isinstance(tp, _GenericAlias):
+            res = tp.__args__
+            if get_origin(tp) is collections.abc.Callable and res[0] is not Ellipsis:
+                res = (list(res[:-1]), res[-1])
+            return res
+        return ()
+    if is_classvar(tp):
+        return (tp.__type__,)
+    if (
+        is_generic_type(tp) or is_union_type(tp) or
+        is_callable_type(tp) or is_tuple_type(tp)
+    ):
+        tree = tp._subs_tree()
+        if isinstance(tree, tuple) and len(tree) > 1:
+            if not evaluate:
+                return tree[1:]
+            res = _eval_args(tree[1:])
+            if get_origin(tp) is Callable and res[0] is not Ellipsis:
+                res = (list(res[:-1]), res[-1])
+            return res
+    return ()
+
+
+def get_generic_type(obj):
+    """Get the generic type of an object if possible, or runtime class otherwise.
+    Examples::
+
+        class Node(Generic[T]):
+            ...
+        type(Node[int]()) == Node
+        get_generic_type(Node[int]()) == Node[int]
+        get_generic_type(Node[T]()) == Node[T]
+        get_generic_type(1) == int
+    """
+
+    gen_type = getattr(obj, '__orig_class__', None)
+    return gen_type if gen_type is not None else type(obj)
+
+
+def get_generic_bases(tp):
+    """Get generic base types of a type or empty tuple if not possible.
+    Example::
+
+        class MyClass(List[int], Mapping[str, List[int]]):
+            ...
+        MyClass.__bases__ == (List, Mapping)
+        get_generic_bases(MyClass) == (List[int], Mapping[str, List[int]])
+    """
+
+    return getattr(tp, '__orig_bases__', ())
+
+
+def typed_dict_keys(td):
+    """If td is a TypedDict class, return a dictionary mapping the typed keys to types.
+    Otherwise, return None. Examples::
+
+        class TD(TypedDict):
+            x: int
+            y: int
+        class Other(dict):
+            x: int
+            y: int
+
+        typed_dict_keys(TD) == {'x': int, 'y': int}
+        typed_dict_keys(dict) == None
+        typed_dict_keys(Other) == None
+    """
+    if isinstance(td, _TypedDictMeta):
+        return td.__annotations__.copy()
+    return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,6 @@ ignore_errors = True
 
 [mypy-azure.functions_worker.protos.*]
 ignore_errors = True
+
+[mypy-azure.functions_worker.typing_inspect]
+ignore_errors = True

--- a/tests/broken_functions/bad_out_annotation/function.json
+++ b/tests/broken_functions/bad_out_annotation/function.json
@@ -1,0 +1,21 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "direction": "out",
+      "name": "foo",
+      "type": "int"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/broken_functions/bad_out_annotation/main.py
+++ b/tests/broken_functions/bad_out_annotation/main.py
@@ -1,5 +1,5 @@
 import azure.functions as azf
 
 
-def main(req, foo: azf.Out[str]):
+def main(req, foo: azf.Out):
     return 'trust me, it is OK!'

--- a/tests/test_broken_functions.py
+++ b/tests/test_broken_functions.py
@@ -51,6 +51,21 @@ class TestMockHost(testutils.AsyncTestCase):
                 r'.*cannot load the wrong_param_dir function'
                 r'.*binding foo is declared to have the "out".*')
 
+    async def test_load_broken__bad_out_annotation(self):
+        async with testutils.start_mockhost(
+                script_root='broken_functions') as host:
+
+            func_id, r = await host.load_function('bad_out_annotation')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Failure)
+
+            self.assertRegex(
+                r.response.result.exception.message,
+                r'.*cannot load the bad_out_annotation function'
+                r'.*binding foo has invalid Out annotation.*')
+
     async def test_load_broken__wrong_binding_dir(self):
         async with testutils.start_mockhost(
                 script_root='broken_functions') as host:

--- a/tests/test_typing_inspect.py
+++ b/tests/test_typing_inspect.py
@@ -1,0 +1,152 @@
+# Imported from https://github.com/ilevkivskyi/typing_inspect/blob/168fa6f7c5c55f720ce6282727211cf4cf6368f6/test_typing_inspect.py
+# Author: Ivan Levkivskyi
+# License: MIT
+
+from azure.functions_worker.typing_inspect import (
+    is_generic_type, is_callable_type, is_tuple_type, is_union_type,
+    is_typevar, is_classvar, get_origin, get_parameters, get_last_args, get_args,
+    get_generic_type, get_generic_bases, get_last_origin, typed_dict_keys,
+)
+from unittest import TestCase, main, skipIf, skipUnless
+from typing import (
+    Union, ClassVar, Callable, Optional, TypeVar, Sequence, Mapping,
+    MutableMapping, Iterable, Generic, List, Any, Dict, Tuple, NamedTuple,
+)
+
+import sys
+NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
+
+
+class IsUtilityTestCase(TestCase):
+    def sample_test(self, fun, samples, nonsamples):
+        for s in samples:
+            self.assertTrue(fun(s))
+        for s in nonsamples:
+            self.assertFalse(fun(s))
+
+    def test_generic(self):
+        T = TypeVar('T')
+        samples = [Generic, Generic[T], Iterable[int], Mapping,
+                   MutableMapping[T, List[int]], Sequence[Union[str, bytes]]]
+        nonsamples = [int, Union[int, str], Union[int, T], ClassVar[List[int]],
+                      Callable[..., T], ClassVar, Optional, bytes, list]
+        self.sample_test(is_generic_type, samples, nonsamples)
+
+    def test_callable(self):
+        samples = [Callable, Callable[..., int],
+                   Callable[[int, int], Iterable[str]]]
+        nonsamples = [int, type, 42, [], List[int],
+                      Union[callable, Callable[..., int]]]
+        self.sample_test(is_callable_type, samples, nonsamples)
+        class MyClass(Callable[[int], int]):
+            pass
+        self.assertTrue(is_callable_type(MyClass))
+
+    def test_tuple(self):
+        samples = [Tuple, Tuple[str, int], Tuple[Iterable, ...]]
+        nonsamples = [int, tuple, 42, List[int], NamedTuple('N', [('x', int)])]
+        self.sample_test(is_tuple_type, samples, nonsamples)
+        class MyClass(Tuple[str, int]):
+            pass
+        self.assertTrue(is_tuple_type(MyClass))
+
+    def test_union(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        samples = [Union, Union[T, int], Union[int, Union[T, S]]]
+        nonsamples = [int, Union[int, int], [], Iterable[Any]]
+        self.sample_test(is_union_type, samples, nonsamples)
+
+    def test_typevar(self):
+        T = TypeVar('T')
+        S_co = TypeVar('S_co', covariant=True)
+        samples = [T, S_co]
+        nonsamples = [int, Union[T, int], Union[T, S_co], type, ClassVar[int]]
+        self.sample_test(is_typevar, samples, nonsamples)
+
+    def test_classvar(self):
+        T = TypeVar('T')
+        samples = [ClassVar, ClassVar[int], ClassVar[List[T]]]
+        nonsamples = [int, 42, Iterable, List[int], type, T]
+        self.sample_test(is_classvar, samples, nonsamples)
+
+
+class GetUtilityTestCase(TestCase):
+
+    @skipIf(NEW_TYPING, "Not supported in Python 3.7")
+    def test_last_origin(self):
+        T = TypeVar('T')
+        self.assertEqual(get_last_origin(int), None)
+        self.assertEqual(get_last_origin(ClassVar[int]), None)
+        self.assertEqual(get_last_origin(Generic[T]), Generic)
+        self.assertEqual(get_last_origin(Union[T, int][str]), Union[T, int])
+        self.assertEqual(get_last_origin(List[Tuple[T, T]][int]), List[Tuple[T, T]])
+        self.assertEqual(get_last_origin(List), List)
+
+    def test_origin(self):
+        T = TypeVar('T')
+        self.assertEqual(get_origin(int), None)
+        self.assertEqual(get_origin(ClassVar[int]), None)
+        self.assertEqual(get_origin(Generic), Generic)
+        self.assertEqual(get_origin(Generic[T]), Generic)
+        self.assertEqual(get_origin(List[Tuple[T, T]][int]), list if NEW_TYPING else List)
+
+    def test_parameters(self):
+        T = TypeVar('T')
+        S_co = TypeVar('S_co', covariant=True)
+        U = TypeVar('U')
+        self.assertEqual(get_parameters(int), ())
+        self.assertEqual(get_parameters(Generic), ())
+        self.assertEqual(get_parameters(Union), ())
+        self.assertEqual(get_parameters(List[int]), ())
+        self.assertEqual(get_parameters(Generic[T]), (T,))
+        self.assertEqual(get_parameters(Tuple[List[T], List[S_co]]), (T, S_co))
+        self.assertEqual(get_parameters(Union[S_co, Tuple[T, T]][int, U]), (U,))
+        self.assertEqual(get_parameters(Mapping[T, Tuple[S_co, T]]), (T, S_co))
+
+    @skipIf(NEW_TYPING, "Not supported in Python 3.7")
+    def test_last_args(self):
+        T = TypeVar('T')
+        S = TypeVar('S')
+        self.assertEqual(get_last_args(int), ())
+        self.assertEqual(get_last_args(Union), ())
+        self.assertEqual(get_last_args(ClassVar[int]), (int,))
+        self.assertEqual(get_last_args(Union[T, int]), (T, int))
+        self.assertEqual(get_last_args(Iterable[Tuple[T, S]][int, T]), (int, T))
+        self.assertEqual(get_last_args(Callable[[T, S], int]), (T, S, int))
+        self.assertEqual(get_last_args(Callable[[], int]), (int,))
+
+    @skipIf(NEW_TYPING, "Not supported in Python 3.7")
+    def test_args(self):
+        T = TypeVar('T')
+        self.assertEqual(get_args(Union[int, Tuple[T, int]][str]),
+                         (int, (Tuple, str, int)))
+        self.assertEqual(get_args(Union[int, Union[T, int], str][int]),
+                         (int, str))
+        self.assertEqual(get_args(int), ())
+
+    def test_args_evaluated(self):
+        T = TypeVar('T')
+        self.assertEqual(get_args(Union[int, Tuple[T, int]][str], evaluate=True),
+                         (int, Tuple[str, int]))
+        self.assertEqual(get_args(Dict[int, Tuple[T, T]][Optional[int]], evaluate=True),
+                         (int, Tuple[Optional[int], Optional[int]]))
+        self.assertEqual(get_args(Callable[[], T][int], evaluate=True), ([], int,))
+
+    def test_generic_type(self):
+        T = TypeVar('T')
+        class Node(Generic[T]): pass
+        self.assertIs(get_generic_type(Node()), Node)
+        self.assertIs(get_generic_type(Node[int]()), Node[int])
+        self.assertIs(get_generic_type(Node[T]()), Node[T],)
+        self.assertIs(get_generic_type(1), int)
+
+    def test_generic_bases(self):
+        class MyClass(List[int], Mapping[str, List[int]]): pass
+        self.assertEqual(get_generic_bases(MyClass),
+                         (List[int], Mapping[str, List[int]]))
+        self.assertEqual(get_generic_bases(int), ())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Python 3.7 has had lots of changes in typing.py, so changes are
necessary in the function signature introspection code.

Issue: #166