### PR TITLE
Add HttpRequest.route_params property to access parsed route arguments

### DIFF
--- a/azure/functions_worker/bindings/http.py
+++ b/azure/functions_worker/bindings/http.py
@@ -15,15 +15,17 @@ class HttpRequest(azf_abc.HttpRequest):
     __body_bytes: typing.Optional[bytes]
     __body_str: typing.Optional[str]
 
-    def __init__(self, method: str, url: str,
+    def __init__(self, method: str, url: str, *,
                  headers: typing.Mapping[str, str],
                  params: typing.Mapping[str, str],
+                 route_params: typing.Mapping[str, str],
                  body_type: meta.TypedDataKind,
                  body: typing.Union[str, bytes]) -> None:
         self.__method = method
         self.__url = url
         self.__headers = azf_http.HttpRequestHeaders(headers)
         self.__params = types.MappingProxyType(params)
+        self.__route_params = types.MappingProxyType(route_params)
         self.__body_type = body_type
 
         if isinstance(body, str):
@@ -51,6 +53,10 @@ class HttpRequest(azf_abc.HttpRequest):
     @property
     def params(self):
         return self.__params
+
+    @property
+    def route_params(self):
+        return self.__route_params
 
     def get_body(self) -> bytes:
         if self.__body_bytes is None:
@@ -147,5 +153,6 @@ class HttpRequestConverter(meta.InConverter,
             url=data.http.url,
             headers=data.http.headers,
             params=data.http.query,
+            route_params=data.http.params,
             body_type=body_type,
             body=body)

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ setup(
     install_requires=[
         'grpcio~=1.14.0',
         'grpcio-tools~=1.14.0',
-        'azure-functions==1.0.0a4',
+        'azure-functions==1.0.0a5',
     ],
     extras_require={
         'dev': [

--- a/tests/http_functions/return_route_params/function.json
+++ b/tests/http_functions/return_route_params/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "route": "return_route_params/{param1}/{param2}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/http_functions/return_route_params/main.py
+++ b/tests/http_functions/return_route_params/main.py
@@ -1,0 +1,6 @@
+import json
+import azure.functions
+
+
+def main(req: azure.functions.HttpRequest) -> str:
+    return json.dumps(dict(req.route_params))

--- a/tests/test_http_functions.py
+++ b/tests/test_http_functions.py
@@ -153,3 +153,9 @@ class TestHttpFunctions(testutils.WebHostTestCase):
         self.assertEqual(r.status_code, 500)
         # https://github.com/Azure/azure-functions-host/issues/2706
         # self.assertIn('Exception: ZeroDivisionError', r.text)
+
+    def test_return_route_params(self):
+        r = self.webhost.request('GET', 'return_route_params/foo/bar')
+        self.assertEqual(r.status_code, 200)
+        resp = r.json()
+        self.assertEqual(resp, {'param1': 'foo', 'param2': 'bar'})

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -14,12 +14,14 @@ class TestFunctions(unittest.TestCase):
             'http://example.com/abc?a=1',
             headers=dict(aaa='zzz', bAb='xYz'),
             params=dict(a='b'),
+            route_params={'route': 'param'},
             body_type=bind_meta.TypedDataKind.bytes,
             body=b'abc')
 
         self.assertEqual(r.method, 'GET')
         self.assertEqual(r.url, 'http://example.com/abc?a=1')
         self.assertEqual(r.params, {'a': 'b'})
+        self.assertEqual(r.route_params, {'route': 'param'})
 
         with self.assertRaises(TypeError):
             r.params['a'] = 'z'
@@ -48,12 +50,14 @@ class TestFunctions(unittest.TestCase):
             'http://example.com/abc?a=1',
             headers={},
             params={},
+            route_params={},
             body_type=bind_meta.TypedDataKind.json,
             body='{"a":1}')
 
         self.assertEqual(r.method, 'POST')
         self.assertEqual(r.url, 'http://example.com/abc?a=1')
         self.assertEqual(r.params, {})
+        self.assertEqual(r.route_params, {})
 
         self.assertEqual(r.get_body(), b'{"a":1}')
         self.assertEqual(r.get_json(), {'a': 1})


### PR DESCRIPTION
Fixes: #198