### PR TITLE
Prevent user exception serialization from failing

### DIFF
--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -166,9 +166,18 @@ class Dispatcher(metaclass=DispatcherMeta):
         return self._worker_id
 
     def _serialize_exception(self, exc):
-        return protos.RpcException(
-            message=f'{type(exc).__name__}: {exc.args[0]}',
-            stack_trace=''.join(traceback.format_tb(exc.__traceback__)))
+        try:
+            message = f'{type(exc).__name__}: {exc}'
+        except Exception:
+            message = (f'Unhandled exception in function. '
+                       f'Could not serialize original exception message.')
+
+        try:
+            stack_trace = ''.join(traceback.format_tb(exc.__traceback__))
+        except Exception:
+            stack_trace = ''
+
+        return protos.RpcException(message=message, stack_trace=stack_trace)
 
     async def _dispatch_grpc_request(self, request):
         content_type = request.WhichOneof('content')

--- a/tests/http_functions/unhandled_unserializable_error/function.json
+++ b/tests/http_functions/unhandled_unserializable_error/function.json
@@ -1,0 +1,16 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/http_functions/unhandled_unserializable_error/main.py
+++ b/tests/http_functions/unhandled_unserializable_error/main.py
@@ -1,0 +1,10 @@
+import azure.functions as func
+
+
+class UnserializableException(Exception):
+    def __str__(self):
+        raise RuntimeError('cannot serialize me')
+
+
+def main(req: func.HttpRequest) -> str:
+    raise UnserializableException('foo')

--- a/tests/http_functions/unhandled_urllib_error/function.json
+++ b/tests/http_functions/unhandled_urllib_error/function.json
@@ -1,0 +1,16 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/http_functions/unhandled_urllib_error/main.py
+++ b/tests/http_functions/unhandled_urllib_error/main.py
@@ -1,0 +1,8 @@
+from urllib.request import urlopen
+
+import azure.functions as func
+
+
+def main(req: func.HttpRequest) -> str:
+    image_url = req.params.get('img')
+    urlopen(image_url).read()

--- a/tests/test_http_functions.py
+++ b/tests/test_http_functions.py
@@ -159,6 +159,17 @@ class TestHttpFunctions(testutils.WebHostTestCase):
         # https://github.com/Azure/azure-functions-host/issues/2706
         # self.assertIn('Exception: ZeroDivisionError', r.text)
 
+    def test_unhandled_urllib_error(self):
+        r = self.webhost.request(
+            'GET', 'unhandled_urllib_error',
+            params={'img': 'http://example.com/nonexistent.jpg'})
+        self.assertEqual(r.status_code, 500)
+
+    def test_unhandled_unserializable_error(self):
+        r = self.webhost.request(
+            'GET', 'unhandled_unserializable_error')
+        self.assertEqual(r.status_code, 500)
+
     def test_return_route_params(self):
         r = self.webhost.request('GET', 'return_route_params/foo/bar')
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
Currently, if an unhandled exception in user function cannot be
serialized properly, the whole worker crashes.  Prevent that from ever
happening.

Fixes: #221