### PR TITLE
Add support for raw data type bindings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ trigger:
 - master
 
 variables:
-    DOTNET_VERSION: '2.1.402'
+    DOTNET_VERSION: '2.2.103'
 
 jobs:
 - job: Tests

--- a/azure/functions_worker/bindings/blob.py
+++ b/azure/functions_worker/bindings/blob.py
@@ -47,8 +47,17 @@ class BlobConverter(meta.InConverter,
                     binding='blob'):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, azf_abc.InputStream)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if (datatype is protos.BindingInfo.undefined
+                or datatype is protos.BindingInfo.stream):
+            return issubclass(pytype, azf_abc.InputStream)
+        elif (datatype is protos.BindingInfo.binary):
+            return issubclass(pytype, bytes)
+        elif (datatype is protos.BindingInfo.string):
+            return issubclass(pytype, str)
+        else:  # Unknown datatype
+            return False
 
     @classmethod
     def check_output_type_annotation(cls, pytype: type) -> bool:
@@ -77,12 +86,41 @@ class BlobConverter(meta.InConverter,
                    pytype: typing.Optional[type],
                    trigger_metadata) -> typing.Any:
         data_type = data.WhichOneof('data')
+
+        if pytype is str:
+            # Bound as dataType: string
+            if data_type == 'string':
+                return data.string
+            else:
+                raise ValueError(
+                    f'unexpected type of data received for the "blob" binding '
+                    f'declared to receive a string: {data_type!r}'
+                )
+
+            return data.string
+
+        elif pytype is bytes:
+            if data_type == 'bytes':
+                return data.bytes
+            elif data_type == 'string':
+                # This should not happen with the correct dataType spec,
+                # but we can be forgiving in this case.
+                return data.string.encode('utf-8')
+            else:
+                raise ValueError(
+                    f'unexpected type of data received for the "blob" binding '
+                    f'declared to receive bytes: {data_type!r}'
+                )
+
         if data_type == 'string':
             data = data.string.encode('utf-8')
         elif data_type == 'bytes':
             data = data.bytes
         else:
-            raise NotImplementedError
+            raise ValueError(
+                f'unexpected type of data received for the "blob" binding '
+                f': {data_type!r}'
+            )
 
         if trigger_metadata is None:
             return InputStream(data=data)

--- a/azure/functions_worker/bindings/cosmosdb.py
+++ b/azure/functions_worker/bindings/cosmosdb.py
@@ -12,8 +12,12 @@ class CosmosDBConverter(meta.InConverter, meta.OutConverter,
                         binding='cosmosDB'):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, cdb.DocumentList)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if datatype is protos.BindingInfo.undefined:
+            return issubclass(pytype, cdb.DocumentList)
+        else:
+            return False
 
     @classmethod
     def check_output_type_annotation(cls, pytype: type) -> bool:

--- a/azure/functions_worker/bindings/eventgrid.py
+++ b/azure/functions_worker/bindings/eventgrid.py
@@ -11,8 +11,12 @@ class EventGridEventInConverter(meta.InConverter,
                                 binding='eventGridTrigger', trigger=True):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, _eventgrid.EventGridEvent)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if datatype is protos.BindingInfo.undefined:
+            return issubclass(pytype, _eventgrid.EventGridEvent)
+        else:
+            return False
 
     @classmethod
     def from_proto(cls, data: protos.TypedData, *,

--- a/azure/functions_worker/bindings/eventhub.py
+++ b/azure/functions_worker/bindings/eventhub.py
@@ -11,8 +11,12 @@ class EventHubConverter(meta.InConverter, meta.OutConverter,
                         binding='eventHub'):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, _eventhub.EventHubEvent)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if datatype is protos.BindingInfo.undefined:
+            return issubclass(pytype, _eventhub.EventHubEvent)
+        else:
+            return False
 
     @classmethod
     def check_output_type_annotation(cls, pytype) -> bool:

--- a/azure/functions_worker/bindings/http.py
+++ b/azure/functions_worker/bindings/http.py
@@ -101,8 +101,12 @@ class HttpRequestConverter(meta.InConverter,
                            binding='httpTrigger', trigger=True):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, azf_abc.HttpRequest)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if datatype is protos.BindingInfo.undefined:
+            return issubclass(pytype, azf_abc.HttpRequest)
+        else:
+            return False
 
     @classmethod
     def from_proto(cls, data: protos.TypedData, *,

--- a/azure/functions_worker/bindings/meta.py
+++ b/azure/functions_worker/bindings/meta.py
@@ -202,7 +202,8 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
 class InConverter(_BaseConverter, binding=None):
 
     @abc.abstractclassmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
         pass
 
     @abc.abstractclassmethod
@@ -257,7 +258,8 @@ def is_trigger_binding(bind_name: str) -> bool:
         raise ValueError(f'unsupported binding type {bind_name!r}')
 
 
-def check_input_type_annotation(binding: str, pytype: type) -> bool:
+def check_input_type_annotation(binding: str, pytype: type,
+                                datatype: protos.BindingInfo.DataType) -> bool:
     try:
         checker = _ConverterMeta._check_in_typeann[binding]
     except KeyError:
@@ -265,7 +267,7 @@ def check_input_type_annotation(binding: str, pytype: type) -> bool:
             f'{binding!r} input binding does not have '
             f'a corresponding Python type') from None
 
-    return checker(pytype)
+    return checker(pytype, datatype)
 
 
 def check_output_type_annotation(binding: str, pytype: type) -> bool:

--- a/azure/functions_worker/bindings/queue.py
+++ b/azure/functions_worker/bindings/queue.py
@@ -56,8 +56,12 @@ class QueueMessageInConverter(meta.InConverter,
                               binding='queueTrigger', trigger=True):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, azf_abc.QueueMessage)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if datatype is protos.BindingInfo.undefined:
+            return issubclass(pytype, azf_abc.QueueMessage)
+        else:
+            return False
 
     @classmethod
     def from_proto(cls, data: protos.TypedData, *,

--- a/azure/functions_worker/bindings/servicebus.py
+++ b/azure/functions_worker/bindings/servicebus.py
@@ -109,8 +109,12 @@ class ServiceBusMessageInConverter(meta.InConverter,
                                    binding='serviceBusTrigger', trigger=True):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, azf_sbus.ServiceBusMessage)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if datatype is protos.BindingInfo.undefined:
+            return issubclass(pytype, azf_sbus.ServiceBusMessage)
+        else:
+            return False
 
     @classmethod
     def from_proto(cls, data: protos.TypedData, *,

--- a/azure/functions_worker/bindings/timer.py
+++ b/azure/functions_worker/bindings/timer.py
@@ -21,8 +21,12 @@ class TimerRequestConverter(meta.InConverter,
                             binding='timerTrigger', trigger=True):
 
     @classmethod
-    def check_input_type_annotation(cls, pytype: type) -> bool:
-        return issubclass(pytype, azf_abc.TimerRequest)
+    def check_input_type_annotation(
+            cls, pytype: type, datatype: protos.BindingInfo.DataType) -> bool:
+        if datatype is protos.BindingInfo.undefined:
+            return issubclass(pytype, azf_abc.TimerRequest)
+        else:
+            return False
 
     @classmethod
     def from_proto(cls, data: protos.TypedData, *,

--- a/azure/functions_worker/functions.py
+++ b/azure/functions_worker/functions.py
@@ -180,16 +180,27 @@ class Registry:
 
             if param_has_anno:
                 if is_param_out:
-                    checker = bindings.check_output_type_annotation
+                    checks_out = bindings.check_output_type_annotation(
+                        param_bind_type, param_py_type)
                 else:
-                    checker = bindings.check_input_type_annotation
+                    checks_out = bindings.check_input_type_annotation(
+                        param_bind_type, param_py_type, desc.data_type)
 
-                if not checker(param_bind_type, param_py_type):
-                    raise FunctionLoadError(
-                        func_name,
-                        f'type of {param.name} binding in function.json '
-                        f'"{param_bind_type}" does not match its Python '
-                        f'annotation "{param_py_type.__name__}"')
+                if not checks_out:
+                    if desc.data_type is not protos.BindingInfo.undefined:
+                        raise FunctionLoadError(
+                            func_name,
+                            f'{param.name!r} binding type "{param_bind_type}" '
+                            f'and dataType "{desc.data_type}" in function.json'
+                            f' do not match the corresponding function '
+                            f'parameter\'s Python type '
+                            f'annotation "{param_py_type.__name__}"')
+                    else:
+                        raise FunctionLoadError(
+                            func_name,
+                            f'type of {param.name} binding in function.json '
+                            f'"{param_bind_type}" does not match its Python '
+                            f'annotation "{param_py_type.__name__}"')
 
             param_type_info = ParamTypeInfo(param_bind_type, param_py_type)
             if is_binding_out:

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from setuptools.command import develop
 
 
 # TODO: change this to something more stable when available.
-WEBHOST_URL = ('https://ci.appveyor.com/api/buildjobs/onhbleqih3dsapp0'
-               '/artifacts/Functions.Binaries.2.0.12136.no-runtime.zip')
+WEBHOST_URL = ('https://ci.appveyor.com/api/buildjobs/k1sofl9yt8n9ocpr'
+               '/artifacts/Functions.Binaries.2.0.12303.no-runtime.zip')
 
 # Extensions necessary for non-core bindings.
 AZURE_EXTENSIONS = [

--- a/tests/blob_functions/get_blob_as_bytes/function.json
+++ b/tests/blob_functions/get_blob_as_bytes/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "dataType": "binary",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-bytes.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/blob_functions/get_blob_as_bytes/main.py
+++ b/tests/blob_functions/get_blob_as_bytes/main.py
@@ -1,0 +1,6 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: bytes) -> str:
+    assert isinstance(file, bytes)
+    return file.decode('utf-8')

--- a/tests/blob_functions/get_blob_as_str/function.json
+++ b/tests/blob_functions/get_blob_as_str/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "main.py",
+  "disabled": false,
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "blob",
+      "direction": "in",
+      "name": "file",
+      "dataType": "string",
+      "connection": "AzureWebJobsStorage",
+      "path": "python-worker-tests/test-str.txt"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/blob_functions/get_blob_as_str/main.py
+++ b/tests/blob_functions/get_blob_as_str/main.py
@@ -1,0 +1,6 @@
+import azure.functions as azf
+
+
+def main(req: azf.HttpRequest, file: str) -> str:
+    assert isinstance(file, str)
+    return file

--- a/tests/test_blob_functions.py
+++ b/tests/test_blob_functions.py
@@ -18,6 +18,10 @@ class TestBlobFunctions(testutils.WebHostTestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'test-data')
 
+        r = self.webhost.request('GET', 'get_blob_as_str')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'test-data')
+
     def test_blob_io_bytes(self):
         r = self.webhost.request('POST', 'put_blob_bytes',
                                  data='test-dată'.encode('utf-8'))
@@ -25,6 +29,10 @@ class TestBlobFunctions(testutils.WebHostTestCase):
         self.assertEqual(r.text, 'OK')
 
         r = self.webhost.request('POST', 'get_blob_bytes')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.text, 'test-dată')
+
+        r = self.webhost.request('POST', 'get_blob_as_bytes')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'test-dată')
 


### PR DESCRIPTION
The generic binding infrastructure now allows annotating the function
argument as `str` or `bytes`.  This also adds support for `str` and
`bytes` binding for the blob functions.

Issue: #66.