### PR TITLE
Make azure namespace compatible with the style of azure-nspkg

### DIFF
--- a/azure/__init__.py
+++ b/azure/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+import typing
+__path__: typing.Iterable[str] = extend_path(__path__, __name__)


### PR DESCRIPTION
azure-nspkg uses pkg_resources.declare_namespace which is incompatible
with PEP 420-style namespaces, which may lead to issues if other Azure
packages are installed in a different location.

Fixes: #268