### PR TITLE
Fix parsing of datetime metadata with 7+ digits in second fraction

### DIFF
--- a/tests/test_eventgrid_functions.py
+++ b/tests/test_eventgrid_functions.py
@@ -28,7 +28,7 @@ class TestEventGridFunctions(testutils.WebHostTestCase):
             "topic": "test-topic",
             "subject": "test-subject",
             "eventType": "Microsoft.Storage.BlobCreated",
-            "eventTime": "2018-01-01T00:00:00.000000Z",
+            "eventTime": "2018-01-01T00:00:00.000000123Z",
             "id": str(uuid.uuid4()),
             "data": {
                 "api": "PutBlockList",


### PR DESCRIPTION
It seems that Azure returns datetime with nanosecond precision, wheras
Python's datetime format only expects microseconds, so strip the extra
digits.

Fixes: #269