### PR TITLE
Always use raw HTTP body

### DIFF
--- a/tests/http_functions/return_request/main.py
+++ b/tests/http_functions/return_request/main.py
@@ -1,4 +1,5 @@
 import json
+import hashlib
 
 import azure.functions
 
@@ -6,10 +7,12 @@ import azure.functions
 def main(req: azure.functions.HttpRequest):
     params = dict(req.params)
     params.pop('code', None)
+    body = req.get_body()
     return json.dumps({
         'method': req.method,
         'url': req.url,
         'headers': dict(req.headers),
         'params': params,
-        'get_body': req.get_body().decode(),
+        'get_body': body.decode(),
+        'body_hash': hashlib.sha256(body).hexdigest(),
     })

--- a/tests/test_http_functions.py
+++ b/tests/test_http_functions.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from azure.functions_worker import testutils
 
 
@@ -140,6 +142,18 @@ class TestHttpFunctions(testutils.WebHostTestCase):
         self.assertIn('return_request', req['url'])
 
         self.assertEqual(req['get_body'], 'key=value')
+
+    def test_post_json_request_is_untouched(self):
+        body = b'{"foo":  "bar", "two":  4}'
+        body_hash = hashlib.sha256(body).hexdigest()
+        r = self.webhost.request(
+            'POST', 'return_request',
+            headers={'Content-Type': 'application/json'},
+            data=body)
+
+        self.assertEqual(r.status_code, 200)
+        req = r.json()
+        self.assertEqual(req['body_hash'], body_hash)
 
     def test_accept_json(self):
         r = self.webhost.request(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -28,7 +28,7 @@ class TestFunctions(unittest.TestCase):
 
         self.assertEqual(r.get_body(), b'abc')
 
-        with self.assertRaisesRegex(ValueError, 'does not have JSON'):
+        with self.assertRaisesRegex(ValueError, 'does not contain valid JSON'):
             r.get_json()
 
         h = r.headers


### PR DESCRIPTION
`RpcHttp.body` may be reformatted by the Functions Host, and as such,
may not be identical to the original body sent by the client.  This has
numerous problems (e.g invalid Content-Length etc.)  Sidestep the issue
by always using `RpcHttp.rawBody`.

See also: Azure/azure-functions-host#3875
Fixes: #260