### PR TITLE
Add Function App directory as a top-level module

### DIFF
--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -82,8 +82,6 @@ class Dispatcher(metaclass=DispatcherMeta):
 
         self._old_task_factory = self._loop.get_task_factory()
 
-        loader.install()
-
         DispatcherMeta.__current_dispatcher__ = self
         try:
             forever = self._loop.create_future()
@@ -209,6 +207,8 @@ class Dispatcher(metaclass=DispatcherMeta):
 
         logger.info('Received FunctionLoadRequest, request ID: %s, '
                     'function ID: %s', self.request_id, function_id)
+                    
+        loader.install_func_app_package(func_request.metadata.directory)
 
         try:
             func = loader.load_function(

--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -82,6 +82,8 @@ class Dispatcher(metaclass=DispatcherMeta):
 
         self._old_task_factory = self._loop.get_task_factory()
 
+        loader.install()
+
         DispatcherMeta.__current_dispatcher__ = self
         try:
             forever = self._loop.create_future()
@@ -207,8 +209,6 @@ class Dispatcher(metaclass=DispatcherMeta):
 
         logger.info('Received FunctionLoadRequest, request ID: %s, '
                     'function ID: %s', self.request_id, function_id)
-                    
-        loader.install_func_app_package(func_request.metadata.directory)
 
         try:
             func = loader.load_function(

--- a/azure/functions_worker/loader.py
+++ b/azure/functions_worker/loader.py
@@ -11,7 +11,7 @@ import sys
 import typing
 
 
-_AZURE_NAMESPACE = '__azure__'
+_AZURE_NAMESPACE = '__app__'
 
 _submodule_dirs = []
 
@@ -22,7 +22,7 @@ def register_function_dir(path: os.PathLike):
 
 def install():
     if _AZURE_NAMESPACE not in sys.modules:
-        # Create and register the __azure__ namespace package.
+        # Create and register the __app__ namespace package.
         ns_spec = importlib.machinery.ModuleSpec(_AZURE_NAMESPACE, None)
         ns_spec.submodule_search_locations = _submodule_dirs
         ns_pkg = importlib.util.module_from_spec(ns_spec)

--- a/azure/functions_worker/loader.py
+++ b/azure/functions_worker/loader.py
@@ -10,23 +10,28 @@ import pathlib
 import sys
 import typing
 
-
-_AZURE_NAMESPACE = '__azure__'
-
 _submodule_dirs = []
+
+
+def extract_func_app_namespace(func_dir):
+    func_dir_path = pathlib.Path(func_dir)
+    func_app_dir = os.path.normpath(func_dir_path.parent)
+    func_app_namespace = os.path.basename(func_app_dir)
+    return func_app_namespace
 
 
 def register_function_dir(path: os.PathLike):
     _submodule_dirs.append(os.fspath(path))
 
 
-def install():
-    if _AZURE_NAMESPACE not in sys.modules:
-        # Create and register the __azure__ namespace package.
-        ns_spec = importlib.machinery.ModuleSpec(_AZURE_NAMESPACE, None)
+def install_func_app_package(func_dir):
+    func_app_namespace = extract_func_app_namespace(func_dir)
+    if func_app_namespace not in sys.modules:
+        # Create and register the function app namespace package.
+        ns_spec = importlib.machinery.ModuleSpec(func_app_namespace, None)
         ns_spec.submodule_search_locations = _submodule_dirs
         ns_pkg = importlib.util.module_from_spec(ns_spec)
-        sys.modules[_AZURE_NAMESPACE] = ns_pkg
+        sys.modules[func_app_namespace] = ns_pkg
 
 
 def uninstall():
@@ -41,6 +46,8 @@ def load_function(name: str, directory: str, script_file: str,
         entry_point = 'main'
 
     register_function_dir(dir_path.parent)
+    
+    func_app_namespace = extract_func_app_namespace(dir_path)
 
     try:
         rel_script_path = script_path.relative_to(dir_path.parent)
@@ -56,8 +63,8 @@ def load_function(name: str, directory: str, script_file: str,
         raise RuntimeError(
             f'cannot load function {name}: '
             f'invalid Python filename {script_file}')
-
-    modname_parts = [_AZURE_NAMESPACE]
+    
+    modname_parts = [func_app_namespace]
     modname_parts.extend(rel_script_path.parts[:-1])
     modname_parts.append(modname)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -10,19 +10,19 @@ class TestLoader(testutils.WebHostTestCase):
     def test_loader_simple(self):
         r = self.webhost.request('GET', 'simple')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.text, '__azure__.simple.main')
+        self.assertEqual(r.text, '__app__.simple.main')
 
     def test_loader_custom_entrypoint(self):
         r = self.webhost.request('GET', 'entrypoint')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.text, '__azure__.entrypoint.main')
+        self.assertEqual(r.text, '__app__.entrypoint.main')
 
     def test_loader_subdir(self):
         r = self.webhost.request('GET', 'subdir')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.text, '__azure__.subdir.sub.main')
+        self.assertEqual(r.text, '__app__.subdir.sub.main')
 
     def test_loader_relimport(self):
         r = self.webhost.request('GET', 'relimport')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.text, '__azure__.relimport.relative')
+        self.assertEqual(r.text, '__app__.relimport.relative')


### PR DESCRIPTION
Given the issues we've been getting for absolute imports over time, wanted to propose a change to the way we are currently handling namespaces for our Function App. Basically, the change involves removing `__azure__` as a top-level module and using the Function Application's directory name as a top-level module. Taking for example the following directory structure:

```
FunctionApp
  Function1
    __init__.py
    func_module.py
  HelperCode
    __init__.py
    helper_module.py
```

FunctionApp would be added as a top-level module instead of `__azure__`. We can then publish guidance to allow users to access absolute imports via the following syntaxes (assuming we are importing from `Function1.__init__.py`):

1. `from FunctionApp import HelperCode`
2. `from FunctionApp.HelperCode import helper_module`

Relative import behavior would remain unchanged. This is likely not the equivalent of what users expect from non-Functions Python but it gets us something in the way of supporting absolute imports (without having to be too heavy-handed with import logic).  