### PR TITLE
Add e2e tests - inital

### DIFF
--- a/.ci/e2e/publish_tests/dev_docker_setup/dev.Dockerfile
+++ b/.ci/e2e/publish_tests/dev_docker_setup/dev.Dockerfile
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE=mcr.microsoft.com/azure-functions/python:2.0
+ARG PYTHON_WORKER_LOCATION=.
+FROM ${BASE_IMAGE}
+
+COPY ${PYTHON_WORKER_LOCATION} /python-worker-dev/
+
+RUN pip install -e /python-worker-dev/ && \
+    rm -rf /azure-functions-host/workers/python/worker.py && \
+    mv /python-worker-dev/python/worker.py /azure-functions-host/workers/python/

--- a/.ci/e2e/publish_tests/dev_docker_setup/setup.sh
+++ b/.ci/e2e/publish_tests/dev_docker_setup/setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -e
+USAGE="usage ./script <ACR_Name> <dev_image_name> <working_dir>"
+
+if [[ -z "$1" ]]
+then
+    echo "Missing name of the ACR"
+    echo ${USAGE}
+    exit 1
+fi
+
+if [[ -z "$2" ]]
+then
+    echo "Missing name of the dev image to use in ACR"
+    echo ${USAGE}
+    exit 1
+fi
+
+if [[ -z "$3" ]]
+then
+    echo "Missing name of the working directory"
+    echo ${USAGE}
+    exit 1
+fi
+
+SCRIPT_DIR=`realpath $(dirname "${BASH_SOURCE[0]}")`
+
+mkdir -p $3
+cd $3
+az acr login --name $1
+git clone https://github.com/Azure/azure-functions-docker
+docker build -f ./azure-functions-docker/host/2.0/stretch/amd64/base.Dockerfile ./azure-functions-docker/host/2.0/stretch/amd64 -t azure-functions-base-dev
+# The directory to build from needs to be the amd64, because the Dockerfile copies resources
+docker build --build-arg BASE_IMAGE=azure-functions-base-dev -f ./azure-functions-docker/host/2.0/stretch/amd64/python.Dockerfile -t azure-functions-python-dev ./azure-functions-docker/host/2.0/stretch/amd64
+docker build --build-arg BASE_IMAGE=azure-functions-python-dev -f ${SCRIPT_DIR}/dev.Dockerfile ${SCRIPT_DIR}/../../../.. -t azure-functions-python-dev-updated
+docker tag azure-functions-python-dev-updated $1.azurecr.io/$2
+docker push $1.azurecr.io/$2
+echo "New image pushed to the ACR."
+echo "Starting cleanup"
+cd ..
+rm -r $3
+echo "Completed cleanup"

--- a/.ci/e2e/publish_tests/dev_func_setup/setup.sh
+++ b/.ci/e2e/publish_tests/dev_func_setup/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e
+if [[ -z "$1" ]]
+then
+    echo "Missing name of the directory to install func CLI"
+    echo "usage ./script <directory_name>"
+    exit 1
+fi
+
+if [[ -z "$2" ]]
+then
+    echo "Missing the URL to download functions"
+fi
+
+wget $2
+echo "Retrieving func CLI version: "
+curl https://functionsclibuilds.blob.core.windows.net/builds/2/latest/version.txt
+echo ""
+unzip *.zip -d "$1"
+rm -rf *.zip
+chmod a+x "$1"/func

--- a/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/build_native_deps_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/build_native_deps_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/helper.sh"
+ensure_usage "$@"
+
+mkdir -p "$1"
+cd "$1"
+git clone https://github.com/asavaritayal/customer-churn-prediction
+cd customer-churn-prediction
+FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps
+
+if [[ $? -eq 0 ]]
+then
+    # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
+    STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
+    verify_status_code $1.result
+else
+    echo "Publishing failed"
+    echo -e "${RED}FAILED${RESET}" > $1.result
+fi
+
+cd ../..
+rm -rf "$1"

--- a/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/no_bundler_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/no_bundler_test.sh
@@ -15,8 +15,19 @@ then
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
     verify_status_code $1.result
 else
-    echo "Publishing failed"
-    echo -e "${RED}FAILED${RESET}" > $1.result
+    echo -e "${RED}Publishing failed (1/2)${RESET}"
+    # Sometimes due to flakiness with the docker daemon or an azure resource may cause it to fail-
+    # So, we retry, but just once
+    echo "Retrying once....."
+    FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps --no-bundler
+    if [[ $? -eq 0 ]]
+    then
+        STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
+        verify_status_code $1.result
+    else
+        echo -e "${RED}Publishing failed (2/2)${RESET}"
+        echo -e "${RED}FAILED${RESET}" > $1.result
+    fi
 fi
 
 cd ../..

--- a/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/no_bundler_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/no_bundler_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/helper.sh"
+ensure_usage "$@"
+
+mkdir -p "$1"
+cd "$1"
+git clone https://github.com/asavaritayal/customer-churn-prediction
+cd customer-churn-prediction
+FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps --no-bundler
+
+if [[ $? -eq 0 ]]
+then
+    # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
+    STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
+    verify_status_code $1.result
+else
+    echo "Publishing failed"
+    echo -e "${RED}FAILED${RESET}" > $1.result
+fi
+
+cd ../..
+rm -rf "$1"

--- a/.ci/e2e/publish_tests/func_tests_core/helpers/helper.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/helpers/helper.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+USAGE="usage ./script <directory_name> <appname> <func_location> <docker_image>"
+# https://stackoverflow.com/questions/5947742/how-to-change-the-output-color-of-echo-in-linux
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m' # No Color
+
+ensure_usage() {
+
+    if [[ -z "$1" ]]
+    then
+        echo "Missing name of the directory"
+        echo ${USAGE}
+        exit 1
+    fi
+
+    if [[ -z "$2" ]]
+    then
+        echo "Missing name of the functions app to publish"
+        echo ${USAGE}
+        exit 1
+    fi
+
+    if [[ -z "$3" ]]
+    then
+        echo "Missing name of the func executable"
+        echo ${USAGE}
+        exit 1
+    fi
+
+    if [[ -z "$4" ]]
+    then
+        echo "Missing name of the docker image to use"
+        echo ${USAGE}
+        exit 1
+    fi
+
+}
+
+# Assuming Status_code is set
+verify_status_code() {
+    if [[ -z "$1" ]]
+    then
+        echo "Missing name of the log file"
+        exit 1
+    fi
+    if [[ "${STATUS_CODE}" -ne 200 ]]
+    then
+        MESSAGE="${RED}TEST FAILED: Expected Status Code 200. Found Status Code ${STATUS_CODE}${RESET}"
+        (>&2 echo -e ${MESSAGE})
+        echo -e "${RED}FAILED${RESET}" > $1
+    else
+        MESSAGE="${GREEN}TEST PASSED: Status Code 200.${RESET}"
+        echo -e ${MESSAGE}
+        echo -e "${GREEN}PASSED${RESET}" > $1
+    fi
+}
+
+fail_after_timeout() {
+    timeout $1 ${@:2}
+}

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
@@ -24,8 +24,19 @@ then
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
     verify_status_code $1.result
 else
-    echo "Publishing failed"
-    echo -e "${RED}FAILED${RESET}" > $1.result
+    echo -e "${RED}Publishing failed (1/2)${RESET}"
+    # Sometimes due to flakiness with the docker daemon or an azure resource may cause it to fail-
+    # So, we retry, but just once
+    echo "Retrying once....."
+    FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps
+    if [[ $? -eq 0 ]]
+    then
+        STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
+        verify_status_code $1.result
+    else
+        echo -e "${RED}Publishing failed (2/2)${RESET}"
+        echo -e "${RED}FAILED${RESET}" > $1.result
+    fi
 fi
 
 deactivate

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/helper.sh"
+ensure_usage "$@"
+
+# Setup a new func app from prod func
+mkdir -p "$1"
+cd "$1"
+python -m venv env_new_build_native
+source env_new_build_native/bin/activate
+"$3" init . --worker-runtime python
+"$3" new --template httptrigger --name httptriggerTest
+FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps
+
+if [[ $? -eq 0 ]]
+then
+    # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
+    STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
+    verify_status_code $1.result
+else
+    echo "Publishing failed"
+    echo -e "${RED}FAILED${RESET}" > $1.result
+fi
+
+deactivate
+cd ..
+rm -rf "$1"

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
@@ -10,6 +10,12 @@ python -m venv env_new_build_native
 source env_new_build_native/bin/activate
 "$3" init . --worker-runtime python
 "$3" new --template httptrigger --name httptriggerTest
+
+# Change auth level to anonymous
+jq '.bindings[].authLevel="anonymous"' httptriggerTest/function.json  > httptriggerTest/replaced.json
+mv httptriggerTest/replaced.json httptriggerTest/function.json
+
+# Publish and verify
 FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps
 
 if [[ $? -eq 0 ]]

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
@@ -24,8 +24,19 @@ then
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
     verify_status_code $1.result
 else
-    echo "Publishing failed"
-    echo -e "${RED}FAILED${RESET}" > $1.result
+    echo -e "${RED}Publishing failed (1/2)${RESET}"
+    # Sometimes due to flakiness with the docker daemon or an azure resource may cause it to fail-
+    # So, we retry, but just once
+    echo "Retrying once....."
+    FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps --no-bundler
+    if [[ $? -eq 0 ]]
+    then
+        STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
+        verify_status_code $1.result
+    else
+        echo -e "${RED}Publishing failed (2/2)${RESET}"
+        echo -e "${RED}FAILED${RESET}" > $1.result
+    fi
 fi
 
 deactivate

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
@@ -10,6 +10,12 @@ python -m venv env_new_build_native
 source env_new_build_native/bin/activate
 "$3" init . --worker-runtime python
 "$3" new --template httptrigger --name httptriggerTest
+
+# Change auth level to anonymous
+jq '.bindings[].authLevel="anonymous"' httptriggerTest/function.json  > httptriggerTest/replaced.json
+mv httptriggerTest/replaced.json httptriggerTest/function.json
+
+# Publish and verify
 FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps --no-bundler
 
 if [[ $? -eq 0 ]]

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/helper.sh"
+ensure_usage "$@"
+
+# Setup a new func app from prod func
+mkdir -p "$1"
+cd "$1"
+python -m venv env_new_build_native
+source env_new_build_native/bin/activate
+"$3" init . --worker-runtime python
+"$3" new --template httptrigger --name httptriggerTest
+FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps --no-bundler
+
+if [[ $? -eq 0 ]]
+then
+    # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
+    STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
+    verify_status_code $1.result
+else
+    echo "Publishing failed"
+    echo -e "${RED}FAILED${RESET}" > $1.result
+fi
+
+deactivate
+cd ..
+rm -rf "$1"

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
@@ -24,8 +24,19 @@ then
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
     verify_status_code $1.result
 else
-    echo "Publishing failed"
-    echo -e "${RED}FAILED${RESET}" > $1.result
+    echo -e "${RED}Publishing failed (1/2)${RESET}"
+    # Sometimes due to flakiness with the docker daemon or an azure resource may cause it to fail-
+    # So, we retry, but just once
+    echo "Retrying once....."
+    FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2"
+    if [[ $? -eq 0 ]]
+    then
+        STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
+        verify_status_code $1.result
+    else
+        echo -e "${RED}Publishing failed (2/2)${RESET}"
+        echo -e "${RED}FAILED${RESET}" > $1.result
+    fi
 fi
 
 deactivate

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
@@ -10,6 +10,12 @@ python -m venv env_new_build_native
 source env_new_build_native/bin/activate
 "$3" init . --worker-runtime python
 "$3" new --template httptrigger --name httptriggerTest
+
+# Change auth level to anonymous
+jq '.bindings[].authLevel="anonymous"' httptriggerTest/function.json  > httptriggerTest/replaced.json
+mv httptriggerTest/replaced.json httptriggerTest/function.json
+
+# Publish and verify
 FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2"
 
 if [[ $? -eq 0 ]]

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/helper.sh"
+ensure_usage "$@"
+
+# Setup a new func app from prod func
+mkdir -p "$1"
+cd "$1"
+python -m venv env_new_build_native
+source env_new_build_native/bin/activate
+"$3" init . --worker-runtime python
+"$3" new --template httptrigger --name httptriggerTest
+FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2"
+
+if [[ $? -eq 0 ]]
+then
+    # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
+    STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
+    verify_status_code $1.result
+else
+    echo "Publishing failed"
+    echo -e "${RED}FAILED${RESET}" > $1.result
+fi
+
+deactivate
+cd ..
+rm -rf "$1"

--- a/.ci/e2e/publish_tests/publish_config.json
+++ b/.ci/e2e/publish_tests/publish_config.json
@@ -1,0 +1,68 @@
+{
+  "azure_service_principal": {
+    "user_id": "${AZURE_SERVICE_PRINCIPAL_USER}",
+    "password": "${AZURE_SERVICE_PRINCIPAL_PASSWORD}",
+    "tenant": "${AZURE_SERVICE_PRINCIPAL_TENANT}"
+  },
+  "docker_setup": {
+    "acr_name": "${ACR_NAME}",
+    "working_dir": "/docker-dir",
+    "dev_image_name": "${ACR_IMAGE_NAME}",
+    "prod_image": "mcr.microsoft.com/azure-functions/python:2.0"
+  },
+  "func_setup": {
+    "func_dev_dir": "/func-dev-dir",
+    "func_dev_url": "https://functionsclibuilds.blob.core.windows.net/builds/2/latest/Azure.Functions.Cli.linux-x64.zip"
+  },
+  "tests": {
+    "working_dir": "/tests-dir",
+    "logs": "/tests-logs",
+    "timeout": "3000s"
+  },
+  "publish_function_app": {
+    "prod_func_prod_docker": {
+      "new_function": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}",
+        "packapp": "${FUNCTION_APP}"
+      },
+      "customer_churn": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}"
+      }
+    },
+    "prod_func_dev_docker": {
+      "new_function": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}",
+        "packapp": "${FUNCTION_APP}"
+      },
+      "customer_churn": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}"
+      }
+    },
+    "dev_func_prod_docker": {
+      "new_function": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}",
+        "packapp": "${FUNCTION_APP}"
+      },
+      "customer_churn": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}"
+      }
+    },
+    "dev_func_dev_docker": {
+      "new_function": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}",
+        "packapp": "${FUNCTION_APP}"
+      },
+      "customer_churn": {
+        "build_native_deps": "${FUNCTION_APP}",
+        "no_bundler": "${FUNCTION_APP}"
+      }
+    }
+  }
+}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/customer_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/customer_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_dev_docker.customer_churn.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/build_native_deps_test.sh" ${WORKING_DIR}/dfddcbnd ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/customer_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/customer_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_dev_docker.customer_churn.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/no_bundler_test.sh" ${WORKING_DIR}/dfddcnb ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/new_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/new_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_dev_docker.new_function.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/build_native_deps_test.sh" ${WORKING_DIR}/dfddnbnd ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/new_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/new_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_dev_docker.new_function.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/no_bundler_test.sh" ${WORKING_DIR}/dfddnnb ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/new_packapp.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_dev_docker/new_packapp.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_dev_docker.new_function.packapp')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/packapp_test.sh" ${WORKING_DIR}/dfddnpa ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/customer_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/customer_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_prod_docker.customer_churn.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/build_native_deps_test.sh" ${WORKING_DIR}/dfpdcbnd ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/customer_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/customer_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_prod_docker.customer_churn.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/no_bundler_test.sh" ${WORKING_DIR}/dfpdcnb ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/new_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/new_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_prod_docker.new_function.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/build_native_deps_test.sh" ${WORKING_DIR}/dfpdnbnd ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/new_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/new_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_prod_docker.new_function.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/no_bundler_test.sh" ${WORKING_DIR}/dfpdnnb ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/new_packapp.sh
+++ b/.ci/e2e/publish_tests/test_runners/dev_func_prod_docker/new_packapp.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.dev_func_prod_docker.new_function.packapp')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/packapp_test.sh" ${WORKING_DIR}/dfpdnpa ${FUNCTION_APP} ${FUNC_DEV_DIR}/func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/helpers/get_config_variables.sh
+++ b/.ci/e2e/publish_tests/test_runners/helpers/get_config_variables.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Get the configuration file
+GLOBAL_CONFIG="$(dirname "${BASH_SOURCE[0]}")/../../publish_config.json"
+if [[ -n "$1" ]]
+then
+    echo "Using the provided global config"
+    GLOBAL_CONFIG=$1
+fi
+
+# Docker Dev Variables
+DOCKER_CONFIG="$(cat "${GLOBAL_CONFIG}" | jq '.docker_setup')"
+ACR_NAME="$(echo "${DOCKER_CONFIG}" | jq -r '.acr_name')"
+DEV_IMAGE_NAME="$(echo "${DOCKER_CONFIG}" | jq -r '.dev_image_name')"
+DEV_DOCKER_IMAGE=${ACR_NAME}.azurecr.io/${DEV_IMAGE_NAME}
+DOCKER_WORKING_DIR="$(echo "${DOCKER_CONFIG}" | jq -r '.working_dir')"
+
+# Docker Prod Variables
+PROD_DOCKER_IMAGE="$(echo "${DOCKER_CONFIG}" | jq -r '.prod_image')"
+
+# Func Dev Variables
+FUNC_CONFIG="$(cat "${GLOBAL_CONFIG}" | jq '.func_setup')"
+FUNC_DEV_DIR="$(echo "${FUNC_CONFIG}" | jq -r '.func_dev_dir')"
+FUNC_DEV_URL="$(echo "${FUNC_CONFIG}" | jq -r '.func_dev_url')"
+
+# Working dir variables
+TESTS_CONFIG="$(cat "${GLOBAL_CONFIG}" | jq '.tests')"
+WORKING_DIR="$(echo "${TESTS_CONFIG}" | jq -r '.working_dir')"
+TESTS_LOGS="$(echo "${TESTS_CONFIG}" | jq -r '.logs')"
+TESTS_TIMEOUT="$(echo "${TESTS_CONFIG}" | jq -r '.timeout')"
+
+# Service Principal variables
+SP_CONFIG="$(cat "${GLOBAL_CONFIG}" | jq '.azure_service_principal')"
+SP_USER_NAME="$(echo "${SP_CONFIG}" | jq -r '.user_id')"
+SP_PASSWORD="$(echo "${SP_CONFIG}" | jq -r '.password')"
+SP_TENANT="$(echo "${SP_CONFIG}" | jq -r '.tenant')"

--- a/.ci/e2e/publish_tests/test_runners/helpers/helper.sh
+++ b/.ci/e2e/publish_tests/test_runners/helpers/helper.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+RESET='\033[0m' # No Color
+YELLOW='\033[1;33m'
+ORANGE='\033[0;33m'
+RED='\033[0;31m'
+
+
+yellow() {
+    echo -e "${YELLOW}$1${RESET}"
+}
+get_result_of() {
+    if [[ -z "$1" ]]
+    then
+        echo -e "${RED}FAILED${RESET}"
+    elif [[ ! -f "$1" ]]
+    then
+        echo -e "${ORANGE}SKIPPED${RESET}"
+    else
+        cat "$1"
+    fi
+}
+
+print_row_line() {
+    # (32 (-10 for colors) + 4) * 6 args + 1 for beauty
+    row=$(printf "%157s" "-")
+    echo "${row// /-}"
+}
+
+print_row() {
+    printf "%-4s" "|"
+    for arg in "$@"
+    do
+        printf "%-32s %-4s" ${arg} "|"
+    done
+    printf "\n"
+}
+
+# Expects a test_script, test_log, timeout, test_result
+run_test() {
+    exit_code=0
+    set -o pipefail
+    chmod a+x $1
+    if [[ ${TESTS_VERBOSE} = "SILENT" ]]
+    then
+        timeout $3 $1 > $2
+        exit_code=$?
+    else
+        timeout $3 $1 2>&1 | tee $2
+        exit_code=$?
+    fi
+    # This means we had a timeout
+    if [[ ${exit_code} = 124 ]]
+    then
+        echo "Test Timed Out!"
+        echo -e "${ORANGE}TIMEOUT${RESET}" > $4
+    fi
+}
+

--- a/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/customer_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/customer_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_dev_docker.customer_churn.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/build_native_deps_test.sh" ${WORKING_DIR}/pfddcbnd ${FUNCTION_APP} func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/customer_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/customer_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_dev_docker.customer_churn.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/no_bundler_test.sh" ${WORKING_DIR}/pfddcnb ${FUNCTION_APP} func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/new_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/new_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_dev_docker.new_function.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/build_native_deps_test.sh" ${WORKING_DIR}/pfddnbnd ${FUNCTION_APP} func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/new_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/new_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_dev_docker.new_function.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/no_bundler_test.sh" ${WORKING_DIR}/pfddnnb ${FUNCTION_APP} func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/new_packapp.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_dev_docker/new_packapp.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_dev_docker.new_function.packapp')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/packapp_test.sh" ${WORKING_DIR}/pfddnpa ${FUNCTION_APP} func ${DEV_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/customer_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/customer_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_prod_docker.customer_churn.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/build_native_deps_test.sh" ${WORKING_DIR}/pfpdcbnd ${FUNCTION_APP} func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/customer_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/customer_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_prod_docker.customer_churn.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/customer_churn_app/no_bundler_test.sh" ${WORKING_DIR}/pfpdcnb ${FUNCTION_APP} func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/new_build_native_deps.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/new_build_native_deps.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_prod_docker.new_function.build_native_deps')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/build_native_deps_test.sh" ${WORKING_DIR}/pfpdnbnd ${FUNCTION_APP} func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/new_no_bundler.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/new_no_bundler.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_prod_docker.new_function.no_bundler')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/no_bundler_test.sh" ${WORKING_DIR}/pfpdnnb ${FUNCTION_APP} func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/new_packapp.sh
+++ b/.ci/e2e/publish_tests/test_runners/prod_func_prod_docker/new_packapp.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers/get_config_variables.sh"
+
+FUNCTION_APP="$(cat "${GLOBAL_CONFIG}" | jq -r '.publish_function_app.prod_func_prod_docker.new_function.packapp')"
+
+"$(dirname "${BASH_SOURCE[0]}")/../../func_tests_core/new_functionapp/packapp_test.sh" ${WORKING_DIR}/pfpdnpa ${FUNCTION_APP} func ${PROD_DOCKER_IMAGE}

--- a/.ci/e2e/publish_tests/test_runners/run_all_parallel.sh
+++ b/.ci/e2e/publish_tests/test_runners/run_all_parallel.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Get the config file
+source "$(dirname "${BASH_SOURCE[0]}")/helpers/get_config_variables.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/helpers/helper.sh"
+
+mkdir -p ${WORKING_DIR}
+mkdir -p ${TESTS_LOGS}
+
+BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
+RESET='\033[0m' # No Color
+BLUE='\033[1;34m'
+YELLOW='\033[1;33m'
+
+# This may be needed if docker image is restarted
+# Better to simply login again at every invoke
+echo "Ensuring login to Azure ACR"
+az acr login --name ${ACR_NAME} > /dev/null
+
+echo -e "Starting Parallel execution in background"
+
+
+run_test ${BASE_DIR}/dev_func_dev_docker/customer_build_native_deps.sh ${TESTS_LOGS}/dfddcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddcbnd.result &
+run_test ${BASE_DIR}/dev_func_dev_docker/customer_no_bundler.sh ${TESTS_LOGS}/dfddcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddcnb.result &
+run_test ${BASE_DIR}/dev_func_dev_docker/new_build_native_deps.sh ${TESTS_LOGS}/dfddnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddnbnd.result &
+run_test ${BASE_DIR}/dev_func_dev_docker/new_no_bundler.sh ${TESTS_LOGS}/dfddnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddnnb.result &
+run_test ${BASE_DIR}/dev_func_dev_docker/new_packapp.sh ${TESTS_LOGS}/dfddnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddnpa.result &
+
+run_test ${BASE_DIR}/dev_func_prod_docker/customer_build_native_deps.sh ${TESTS_LOGS}/dfpdcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdcbnd.result &
+run_test ${BASE_DIR}/dev_func_prod_docker/customer_no_bundler.sh ${TESTS_LOGS}/dfpdcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdcnb.result &
+run_test ${BASE_DIR}/dev_func_prod_docker/new_build_native_deps.sh ${TESTS_LOGS}/dfpdnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdnbnd.result &
+run_test ${BASE_DIR}/dev_func_prod_docker/new_no_bundler.sh ${TESTS_LOGS}/dfpdnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdnnb.result &
+run_test ${BASE_DIR}/dev_func_prod_docker/new_packapp.sh ${TESTS_LOGS}/dfpdnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdnpa.result &
+
+run_test ${BASE_DIR}/prod_func_prod_docker/customer_build_native_deps.sh ${TESTS_LOGS}/pfpdcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdcbnd.result &
+run_test ${BASE_DIR}/prod_func_prod_docker/customer_no_bundler.sh ${TESTS_LOGS}/pfpdcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdcnb.result &
+run_test ${BASE_DIR}/prod_func_prod_docker/new_build_native_deps.sh ${TESTS_LOGS}/pfpdnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdnbnd.result &
+run_test ${BASE_DIR}/prod_func_prod_docker/new_no_bundler.sh ${TESTS_LOGS}/pfpdnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdnnb.result &
+run_test ${BASE_DIR}/prod_func_prod_docker/new_packapp.sh ${TESTS_LOGS}/pfpdnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdnpa.result &
+
+run_test ${BASE_DIR}/prod_func_dev_docker/customer_build_native_deps.sh ${TESTS_LOGS}/pfddcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddcbnd.result &
+run_test ${BASE_DIR}/prod_func_dev_docker/customer_no_bundler.sh ${TESTS_LOGS}/pfddcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddcnb.result &
+run_test ${BASE_DIR}/prod_func_dev_docker/new_build_native_deps.sh ${TESTS_LOGS}/pfddnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddnbnd.result &
+run_test ${BASE_DIR}/prod_func_dev_docker/new_no_bundler.sh ${TESTS_LOGS}/pfddnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddnnb.result &
+run_test ${BASE_DIR}/prod_func_dev_docker/new_packapp.sh ${TESTS_LOGS}/pfddnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddnpa.result &
+
+echo "Waiting for tests to complete (this may take several minutes)..."
+wait
+
+echo "Test Completed!"
+yellow "Results-"
+printf "\n"
+
+print_row $(yellow "Version") $(yellow "Exist-Build-Native") \
+$(yellow "Exist-No-Bundler") $(yellow "New-Build-Native") $(yellow "New-No-Bundler") $(yellow "New-Packapp")
+
+print_row_line
+
+print_row $(yellow "dev-func-dev-docker") $(get_result_of ${WORKING_DIR}/dfddcbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfddcnb.result) $(get_result_of ${WORKING_DIR}/dfddnbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfddnnb.result) $(get_result_of ${WORKING_DIR}/dfddnpa.result)
+
+print_row $(yellow "dev-func-dev-docker") $(get_result_of ${WORKING_DIR}/dfpdcbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfpdcnb.result) $(get_result_of ${WORKING_DIR}/dfpdnbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfpdnnb.result) $(get_result_of ${WORKING_DIR}/dfpdnpa.result)
+
+print_row $(yellow "dev-func-dev-docker") $(get_result_of ${WORKING_DIR}/pfddcbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfddcnb.result) $(get_result_of ${WORKING_DIR}/pfddnbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfddnnb.result) $(get_result_of ${WORKING_DIR}/pfddnpa.result)
+
+print_row $(yellow "dev-func-dev-docker") $(get_result_of ${WORKING_DIR}/pfpdcbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfpdcnb.result) $(get_result_of ${WORKING_DIR}/pfpdnbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfpdnnb.result) $(get_result_of ${WORKING_DIR}/pfpdnpa.result)
+
+
+# This is useful when running in a container environment
+printf "\n"
+echo "All logs are available at ${TESTS_LOGS}"
+echo "Sleeping for infinity, in case you need to open bash in the container"
+if [[ ${ENVIRONMENT} = "DOCKER" ]]
+then
+    sleep infinity
+fi
+
+if [[ ${EXIT_ON_FAIL} -ne "FALSE" ]]
+then
+    NUMBER_PASSED=$(grep -l "PASSED" ${WORKING_DIR}/*.result | wc -l)
+    if [[ ${NUMBER_PASSED} -ne 20 ]]
+    then
+        echo "Not all (20) tests passed! Dieing.."
+        exit 1
+    else
+        echo "All tests passed (20/20)!"
+    fi
+fi

--- a/.ci/e2e/publish_tests/test_runners/run_all_serial.sh
+++ b/.ci/e2e/publish_tests/test_runners/run_all_serial.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Get the config file
+source "$(dirname "${BASH_SOURCE[0]}")/helpers/get_config_variables.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/helpers/helper.sh"
+
+mkdir -p ${WORKING_DIR}
+mkdir -p ${TESTS_LOGS}
+
+BASE_DIR="$(dirname "${BASH_SOURCE[0]}")"
+RESET='\033[0m' # No Color
+BLUE='\033[1;34m'
+YELLOW='\033[1;33m'
+
+# This may be needed if docker image is restarted
+# Better to simply login again at every invoke
+echo "Ensuring login to Azure ACR"
+az acr login --name ${ACR_NAME} > /dev/null
+
+echo -e "Starting Serial Execution..."
+echo "This will take a while"
+
+
+run_test ${BASE_DIR}/dev_func_dev_docker/customer_build_native_deps.sh ${TESTS_LOGS}/dfddcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddcbnd.result
+run_test ${BASE_DIR}/dev_func_dev_docker/customer_no_bundler.sh ${TESTS_LOGS}/dfddcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddcnb.result
+run_test ${BASE_DIR}/dev_func_dev_docker/new_build_native_deps.sh ${TESTS_LOGS}/dfddnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddnbnd.result
+run_test ${BASE_DIR}/dev_func_dev_docker/new_no_bundler.sh ${TESTS_LOGS}/dfddnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddnnb.result
+run_test ${BASE_DIR}/dev_func_dev_docker/new_packapp.sh ${TESTS_LOGS}/dfddnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfddnpa.result
+
+run_test ${BASE_DIR}/dev_func_prod_docker/customer_build_native_deps.sh ${TESTS_LOGS}/dfpdcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdcbnd.result
+run_test ${BASE_DIR}/dev_func_prod_docker/customer_no_bundler.sh ${TESTS_LOGS}/dfpdcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdcnb.result
+run_test ${BASE_DIR}/dev_func_prod_docker/new_build_native_deps.sh ${TESTS_LOGS}/dfpdnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdnbnd.result
+run_test ${BASE_DIR}/dev_func_prod_docker/new_no_bundler.sh ${TESTS_LOGS}/dfpdnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdnnb.result
+run_test ${BASE_DIR}/dev_func_prod_docker/new_packapp.sh ${TESTS_LOGS}/dfpdnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/dfpdnpa.result
+
+run_test ${BASE_DIR}/prod_func_prod_docker/customer_build_native_deps.sh ${TESTS_LOGS}/pfpdcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdcbnd.result
+run_test ${BASE_DIR}/prod_func_prod_docker/customer_no_bundler.sh ${TESTS_LOGS}/pfpdcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdcnb.result
+run_test ${BASE_DIR}/prod_func_prod_docker/new_build_native_deps.sh ${TESTS_LOGS}/pfpdnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdnbnd.result
+run_test ${BASE_DIR}/prod_func_prod_docker/new_no_bundler.sh ${TESTS_LOGS}/pfpdnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdnnb.result
+run_test ${BASE_DIR}/prod_func_prod_docker/new_packapp.sh ${TESTS_LOGS}/pfpdnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfpdnpa.result
+
+echo "Ensuring login to Azure ACR (again because login has been flaky)"
+az acr login --name ${ACR_NAME} > /dev/null
+run_test ${BASE_DIR}/prod_func_dev_docker/customer_build_native_deps.sh ${TESTS_LOGS}/pfddcbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddcbnd.result
+run_test ${BASE_DIR}/prod_func_dev_docker/customer_no_bundler.sh ${TESTS_LOGS}/pfddcnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddcnb.result
+run_test ${BASE_DIR}/prod_func_dev_docker/new_build_native_deps.sh ${TESTS_LOGS}/pfddnbnd.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddnbnd.result
+run_test ${BASE_DIR}/prod_func_dev_docker/new_no_bundler.sh ${TESTS_LOGS}/pfddnnb.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddnnb.result
+run_test ${BASE_DIR}/prod_func_dev_docker/new_packapp.sh ${TESTS_LOGS}/pfddnpa.log ${TESTS_TIMEOUT} ${WORKING_DIR}/pfddnpa.result
+
+echo "Test Completed!"
+yellow "Results-"
+printf "\n"
+
+print_row $(yellow "Version") $(yellow "Exist-Build-Native") \
+$(yellow "Exist-No-Bundler") $(yellow "New-Build-Native") $(yellow "New-No-Bundler") $(yellow "New-Packapp")
+
+print_row_line
+
+print_row $(yellow "dev-func-dev-docker") $(get_result_of ${WORKING_DIR}/dfddcbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfddcnb.result) $(get_result_of ${WORKING_DIR}/dfddnbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfddnnb.result) $(get_result_of ${WORKING_DIR}/dfddnpa.result)
+
+print_row $(yellow "dev-func-prod-docker") $(get_result_of ${WORKING_DIR}/dfpdcbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfpdcnb.result) $(get_result_of ${WORKING_DIR}/dfpdnbnd.result) \
+$(get_result_of ${WORKING_DIR}/dfpdnnb.result) $(get_result_of ${WORKING_DIR}/dfpdnpa.result)
+
+print_row $(yellow "prod-func-dev-docker") $(get_result_of ${WORKING_DIR}/pfddcbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfddcnb.result) $(get_result_of ${WORKING_DIR}/pfddnbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfddnnb.result) $(get_result_of ${WORKING_DIR}/pfddnpa.result)
+
+print_row $(yellow "prod-func-prod-docker") $(get_result_of ${WORKING_DIR}/pfpdcbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfpdcnb.result) $(get_result_of ${WORKING_DIR}/pfpdnbnd.result) \
+$(get_result_of ${WORKING_DIR}/pfpdnnb.result) $(get_result_of ${WORKING_DIR}/pfpdnpa.result)
+
+printf "\n"
+echo "All logs are available at ${TESTS_LOGS}"
+
+if [[ ${ENVIRONMENT} = "DOCKER" ]]
+then
+    # This is useful when running in a container environment
+    echo "Sleeping for infinity, in case you need to open bash in the container"
+    sleep infinity
+fi
+
+if [[ -z ${EXIT_ON_FAIL} ]] || [[ ${EXIT_ON_FAIL} -ne "FALSE" ]]
+then
+    NUMBER_PASSED=$(grep -l "PASSED" ${WORKING_DIR}/*.result | wc -l)
+    if [[ ${NUMBER_PASSED} -ne 20 ]]
+    then
+        echo "Not all (20) tests passed! Dieing.."
+        exit 1
+    else
+        echo "All tests passed (20/20)!"
+    fi
+fi

--- a/.ci/e2e/publish_tests/test_runners/setup_container_environment.sh
+++ b/.ci/e2e/publish_tests/test_runners/setup_container_environment.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+apt-get update
+apt-get install azure-functions-core-tools jq git unzip gettext -y
+curl -sSL https://get.docker.com/ | sh
+
+# Install azure CLI
+apt-get install apt-transport-https lsb-release software-properties-common dirmngr -y
+AZ_REPO=$(lsb_release -cs)
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list
+apt-key --keyring /etc/apt/trusted.gpg.d/Microsoft.gpg adv --keyserver packages.microsoft.com --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF
+apt-get update
+apt-get install azure-cli -y

--- a/.ci/e2e/publish_tests/test_runners/setup_test_environment.sh
+++ b/.ci/e2e/publish_tests/test_runners/setup_test_environment.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+# Get the configuration variables
+source "$(dirname "${BASH_SOURCE[0]}")/helpers/get_config_variables.sh"
+
+# Login to the Service Principal Azure Account
+az login --service-principal -u ${SP_USER_NAME} -p ${SP_PASSWORD} --tenant ${SP_TENANT}
+
+# Update the ACR Docker Image with the dev branch of Docker image and python worker
+chmod a+x $(dirname "${BASH_SOURCE[0]}")/../dev_docker_setup/setup.sh
+$(dirname "${BASH_SOURCE[0]}")/../dev_docker_setup/setup.sh ${ACR_NAME} ${DEV_IMAGE_NAME} ${DOCKER_WORKING_DIR}
+
+# Setup the dev func executables
+chmod a+x $(dirname "${BASH_SOURCE[0]}")/../dev_func_setup/setup.sh
+$(dirname "${BASH_SOURCE[0]}")/../dev_func_setup/setup.sh ${FUNC_DEV_DIR} ${FUNC_DEV_URL}

--- a/.ci/e2e/running-environments/Docker/start_tests_docker.sh
+++ b/.ci/e2e/running-environments/Docker/start_tests_docker.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# This needs to happen after the docker container is built. This is because the setup uses Docker deamon
+# And the /var/run/docker.sock needs to be mounted for the setup script to use Docker.
+# This is done when the Docker container is run.
+/azure-functions-python-worker/.ci/e2e/publish_tests/test_runners/setup_test_environment.sh
+
+/azure-functions-python-worker/.ci/e2e/publish_tests/test_runners/run_all_serial.sh

--- a/.ci/e2e/running-environments/Docker/test_runner.Dockerfile
+++ b/.ci/e2e/running-environments/Docker/test_runner.Dockerfile
@@ -1,0 +1,28 @@
+# When running, make sure to mount Docker sock and use the python-worker directory as the base dir
+# Example-
+# docker build -f .ci\e2e\running-environments\Docker\test_runner.Dockerfile -t my-test-image <path-to-python-worker>
+# docker run -v /var/run/docker.sock:/var/run/docker.sock my-test-image
+
+FROM mcr.microsoft.com/azure-functions/python:2.0
+
+COPY . /azure-functions-python-worker
+
+RUN apt-get update && \
+    apt-get install azure-functions-core-tools jq git unzip -y
+
+# Install docker amd azure CLI
+RUN curl -sSL https://get.docker.com/ | sh && \
+    apt-get update && \
+    apt-get install apt-transport-https lsb-release software-properties-common dirmngr -y && \
+    AZ_REPO=$(lsb_release -cs) && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+    apt-key --keyring /etc/apt/trusted.gpg.d/Microsoft.gpg adv --keyserver packages.microsoft.com --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF && \
+    apt-get update && \
+    apt-get install azure-cli -y
+
+# RUN bash /azure-functions-python-worker/.ci/e2e/publish_tests/test_runners/setup_test_environment.sh
+
+ENV ENVIRONMENT=DOCKER
+ENV EXIT_ON_FAIL=FALSE
+
+CMD [ "bash", "/azure-functions-python-worker/.ci/e2e/running-environments/Docker/start_tests_docker.sh" ]

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -1,0 +1,52 @@
+jobs:
+- job: LinuxNightly
+  timeoutInMinutes: 0
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+      addToPath: true
+    name: pythonPath
+    displayName: Update Python Path
+  - bash: |
+
+      echo "alias python=$(pythonPath.pythonLocation)/python" > ~/.bashrc
+      which python
+
+      sudo apt-get update
+      sudo apt-get install azure-functions-core-tools jq git unzip gettext -y
+
+      # Install azure CLI
+      sudo apt-get install apt-transport-https lsb-release software-properties-common dirmngr -y
+      AZ_REPO=$(lsb_release -cs)
+      sudo echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list
+      sudo apt-key --keyring /etc/apt/trusted.gpg.d/Microsoft.gpg adv --keyserver packages.microsoft.com --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF
+      sudo apt-get update
+      sudo apt-get install azure-cli -y
+    displayName: Initial Setup
+    continueOnError: false
+  - bash: |
+      envsubst < .ci/e2e/publish_tests/publish_config.json > .ci/e2e/publish_tests/publish_config_filled.json
+      mv .ci/e2e/publish_tests/publish_config_filled.json .ci/e2e/publish_tests/publish_config.json
+    displayName: Populate Settings
+    continueOnError: false
+    env:
+      AZURE_SERVICE_PRINCIPAL_USER: $(AZURE_SERVICE_PRINCIPAL_USER)
+      AZURE_SERVICE_PRINCIPAL_PASSWORD: ${AZURE_SERVICE_PRINCIPAL_PASSWORD}
+      AZURE_SERVICE_PRINCIPAL_TENANT: $(AZURE_SERVICE_PRINCIPAL_TENANT)
+      ACR_NAME: $(ACR_NAME)
+      ACR_IMAGE_NAME: $(ACR_IMAGE_NAME)
+      FUNCTION_APP: $(FUNCTION_APP)
+  - bash: |
+      chmod a+x .ci/e2e/publish_tests/test_runners/setup_test_environment.sh
+      sudo .ci/e2e/publish_tests/test_runners/setup_test_environment.sh
+    displayName: Setup Testing artifacts
+    continueOnError: false
+  - bash: |
+      chmod a+x .ci/e2e/publish_tests/test_runners/run_all_serial.sh
+      find .ci/e2e/publish_tests/ -type f -iname "*.sh" -exec chmod a+x {} \;
+      sudo PATH=${PATH} .ci/e2e/publish_tests/test_runners/run_all_serial.sh
+    displayName: E2E Tests
+    continueOnError: false


### PR DESCRIPTION
Closes https://github.com/Azure/azure-functions-core-tools/issues/971 and maybe(?) https://github.com/Azure/azure-functions-python-worker/issues/274
[We discussed that Python tests should belong in this repo]

Adding a bunch of e2e tests:

These can be run in two ways-
1. Using Azure pipelines from the `azure-pipelines-nightly.yml` which will be a nightly build.
2. Using a local docker container.

**Using a local docker container**
You would need to fill out the `.ci/e2e/publish_tests/publish_config.json` appropriately with your own azure resources and run these two commands-
```
docker build -f .ci\e2e\running-environments\Docker\test_runner.Dockerfile -t my-test-image <path-to-python-worker>
docker run -v /var/run/docker.sock:/var/run/docker.sock my-test-image
```

I will make a wiki page on the structure, details on the implementation and how to run these once/if this PR is approved.

once ran, and if things go well, you should get an output like this-

<img width="898" alt="capture" src="https://user-images.githubusercontent.com/16520682/53058875-af5f9c80-3469-11e9-86cb-634d6de9ff53.PNG">


\cc @pragnagopa @ahmelsayed @maiqbal11 @fabiocav @elprans @asavaritayal 