### PR TITLE
Update CI tests for more control

### DIFF
--- a/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/build_native_deps_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/build_native_deps_test.sh
@@ -11,6 +11,7 @@ FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-nat
 
 if [[ $? -eq 0 ]]
 then
+    sleep 5s
     # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
     verify_status_code $1.result
@@ -22,6 +23,7 @@ else
     FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps
     if [[ $? -eq 0 ]]
     then
+        sleep 5s
         STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
         verify_status_code $1.result
     else

--- a/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/no_bundler_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/customer_churn_app/no_bundler_test.sh
@@ -11,6 +11,7 @@ FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-nat
 
 if [[ $? -eq 0 ]]
 then
+    sleep 5s
     # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
     verify_status_code $1.result
@@ -22,6 +23,7 @@ else
     FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps --no-bundler
     if [[ $? -eq 0 ]]
     then
+        sleep 5s
         STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/predict)
         verify_status_code $1.result
     else

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/build_native_deps_test.sh
@@ -20,6 +20,7 @@ FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-nat
 
 if [[ $? -eq 0 ]]
 then
+    sleep 5s
     # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
     verify_status_code $1.result
@@ -31,6 +32,7 @@ else
     FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps
     if [[ $? -eq 0 ]]
     then
+        sleep 5s
         STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
         verify_status_code $1.result
     else

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/no_bundler_test.sh
@@ -20,6 +20,7 @@ FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-nat
 
 if [[ $? -eq 0 ]]
 then
+    sleep 5s
     # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
     verify_status_code $1.result
@@ -31,6 +32,7 @@ else
     FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2" --build-native-deps --no-bundler
     if [[ $? -eq 0 ]]
     then
+        sleep 5s
         STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
         verify_status_code $1.result
     else

--- a/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
+++ b/.ci/e2e/publish_tests/func_tests_core/new_functionapp/packapp_test.sh
@@ -20,6 +20,7 @@ FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2"
 
 if [[ $? -eq 0 ]]
 then
+    sleep 5s
     # https://stackoverflow.com/questions/2220301/how-to-evaluate-http-response-codes-from-bash-shell-script
     STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
     verify_status_code $1.result
@@ -31,6 +32,7 @@ else
     FUNCTIONS_PYTHON_DOCKER_IMAGE=$4 "$3" azure functionapp publish "$2"
     if [[ $? -eq 0 ]]
     then
+        sleep 5s
         STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null https://$2.azurewebsites.net/api/httptriggerTest?name=test)
         verify_status_code $1.result
     else

--- a/.ci/e2e/publish_tests/publish_config.json
+++ b/.ci/e2e/publish_tests/publish_config.json
@@ -12,7 +12,7 @@
   },
   "func_setup": {
     "func_dev_dir": "/func-dev-dir",
-    "func_dev_url": "https://functionsclibuilds.blob.core.windows.net/builds/2/latest/Azure.Functions.Cli.linux-x64.zip"
+    "func_dev_url": "${FUNC_DEV_URL}"
   },
   "tests": {
     "working_dir": "/tests-dir",

--- a/.ci/e2e/running-environments/Docker/test_runner.Dockerfile
+++ b/.ci/e2e/running-environments/Docker/test_runner.Dockerfile
@@ -8,7 +8,7 @@ FROM mcr.microsoft.com/azure-functions/python:2.0
 COPY . /azure-functions-python-worker
 
 RUN apt-get update && \
-    apt-get install azure-functions-core-tools jq git unzip -y
+    apt-get install azure-functions-core-tools jq git unzip dos2unix -y
 
 # Install docker amd azure CLI
 RUN curl -sSL https://get.docker.com/ | sh && \
@@ -20,9 +20,9 @@ RUN curl -sSL https://get.docker.com/ | sh && \
     apt-get update && \
     apt-get install azure-cli -y
 
-# RUN bash /azure-functions-python-worker/.ci/e2e/publish_tests/test_runners/setup_test_environment.sh
-
 ENV ENVIRONMENT=DOCKER
 ENV EXIT_ON_FAIL=FALSE
+
+RUN find /azure-functions-python-worker/.ci/e2e -type f -print0 | xargs -0 dos2unix
 
 CMD [ "bash", "/azure-functions-python-worker/.ci/e2e/running-environments/Docker/start_tests_docker.sh" ]

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -39,6 +39,7 @@ jobs:
       ACR_NAME: $(ACR_NAME)
       ACR_IMAGE_NAME: $(ACR_IMAGE_NAME)
       FUNCTION_APP: $(FUNCTION_APP)
+      FUNC_DEV_URL: $(FUNC_DEV_URL)
   - bash: |
       chmod a+x .ci/e2e/publish_tests/test_runners/setup_test_environment.sh
       sudo .ci/e2e/publish_tests/test_runners/setup_test_environment.sh


### PR DESCRIPTION
Three changes:

1. Add ability to override the func artifacts link in the CI
2. Add a 5 second delay between publish and trigger test. Because sometimes, the trigger test is too quick and it returns a 404.
3. Change line endings when copying scripts to a docker container.