### PR TITLE
Handle cases where ServiceBus message has no payload

### DIFF
--- a/azure/functions_worker/bindings/servicebus.py
+++ b/azure/functions_worker/bindings/servicebus.py
@@ -131,6 +131,11 @@ class ServiceBusMessageInConverter(meta.InConverter,
         elif data_type == 'json':
             body = data.json.encode('utf-8')
 
+        elif data_type is None:
+            # ServiceBus message with no payload are possible.
+            # See Azure/azure-functions-python-worker#330
+            body = b''
+
         else:
             raise NotImplementedError(
                 f'unsupported queue payload type: {data_type}')


### PR DESCRIPTION
Apparently, a Service Bus message may have no payload at the protocol
level, so the worker must account for that.

Fixes: #330