### PR TITLE
Add support for out-of-tree bindings

### DIFF
--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -11,6 +11,7 @@ import threading
 import traceback
 
 import grpc
+import pkg_resources
 
 from . import bindings
 from . import functions
@@ -63,6 +64,16 @@ class Dispatcher(metaclass=DispatcherMeta):
         self._grpc_connected_fut = loop.create_future()
         self._grpc_thread = threading.Thread(
             name='grpc-thread', target=self.__poll_grpc)
+
+    def load_bindings(self):
+        """Load out-of-tree binding implementations."""
+        services = {}
+
+        for ep in pkg_resources.iter_entry_points('azure.functions.bindings'):
+            logger.info('Loading binding plugin from %s', ep.module_name)
+            ep.load()
+
+        return services
 
     @classmethod
     async def connect(cls, host, port, worker_id, request_id,

--- a/azure/functions_worker/main.py
+++ b/azure/functions_worker/main.py
@@ -48,4 +48,6 @@ async def start_async(host, port, worker_id, request_id, grpc_max_msg_len):
         host, port, worker_id, request_id,
         connect_timeout=5.0, max_msg_len=grpc_max_msg_len)
 
+    disp.load_bindings()
+
     await disp.dispatch_forever()

--- a/azure/functions_worker/testutils.py
+++ b/azure/functions_worker/testutils.py
@@ -415,6 +415,8 @@ class _MockWebHostController:
             self._host.worker_id, self._host.request_id,
             connect_timeout=5.0)
 
+        self._worker.load_bindings()
+
         self._worker_task = loop.create_task(self._worker.dispatch_forever())
 
         done, pending = await asyncio.wait(

--- a/tests/test-binding/foo/binding.py
+++ b/tests/test-binding/foo/binding.py
@@ -1,0 +1,6 @@
+from azure.functions_worker.bindings import meta
+
+
+class Binding(meta.InConverter, meta.OutConverter,
+              binding='fooType'):
+    pass

--- a/tests/test-binding/functions/foo/function.json
+++ b/tests/test-binding/functions/foo/function.json
@@ -1,0 +1,11 @@
+{
+  "scriptFile": "main.py",
+
+  "bindings": [
+    {
+      "type": "fooType",
+      "direction": "in",
+      "name": "req"
+    }
+  ]
+}

--- a/tests/test-binding/functions/foo/main.py
+++ b/tests/test-binding/functions/foo/main.py
@@ -1,0 +1,2 @@
+def main(req):
+    pass

--- a/tests/test-binding/setup.py
+++ b/tests/test-binding/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+
+setup(
+    name='foo-binding',
+    version='1.0',
+    packages=['foo'],
+    entry_points={
+        'azure.functions.bindings': [
+            'foo=foo.binding:Binding',
+        ]
+    },
+)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,3 +1,9 @@
+import asyncio
+import pathlib
+import subprocess
+import sys
+import textwrap
+
 from azure.functions_worker import testutils
 
 
@@ -26,3 +32,49 @@ class TestLoader(testutils.WebHostTestCase):
         r = self.webhost.request('GET', 'relimport')
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, '__app__.relimport.relative')
+
+
+class TestPluginLoader(testutils.AsyncTestCase):
+
+    async def test_entry_point_plugin(self):
+        test_binding = pathlib.Path(__file__).parent / 'test-binding'
+        subprocess.run([
+            sys.executable, '-m', 'pip',
+            '--disable-pip-version-check',
+            'install', '--quiet',
+            '-e', test_binding
+        ], check=True)
+
+        # This test must be run in a subprocess so that
+        # pkg_resources picks up the newly installed package.
+        code = textwrap.dedent('''
+        import asyncio
+        from azure.functions_worker import protos
+        from azure.functions_worker import testutils
+
+        async def _runner():
+            async with testutils.start_mockhost(
+                    script_root='test-binding/functions') as host:
+                func_id, r = await host.load_function('foo')
+
+                print(r.response.function_id == func_id)
+                print(r.response.result.status == protos.StatusResult.Success)
+
+        asyncio.get_event_loop().run_until_complete(_runner())
+        ''')
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable, '-c', code,
+                stdout=asyncio.subprocess.PIPE)
+
+            stdout, stderr = await proc.communicate()
+
+            self.assertEqual(stdout.strip().split(b'\n'), [b'True', b'True'])
+
+        finally:
+            subprocess.run([
+                sys.executable, '-m', 'pip',
+                '--disable-pip-version-check',
+                'uninstall', '-y', '--quiet', 'foo-binding'
+            ], check=True)


### PR DESCRIPTION
Use the setuptools entry_point infrastructure to automatically load
binding modules installed in the environment.

Fixes: #381.