### PR TITLE
Fix issue with Date Time Format.

### DIFF
--- a/azure/functions_worker/bindings/meta.py
+++ b/azure/functions_worker/bindings/meta.py
@@ -167,20 +167,22 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
         # UTC ISO 8601 assumed
         formats = [
             '%Y-%m-%dT%H:%M:%S+00:00',
+            '%Y-%m-%dT%H:%M:%S-00:00',
             '%Y-%m-%dT%H:%M:%S.%f+00:00',
+            '%Y-%m-%dT%H:%M:%S.%f-00:00',
             '%Y-%m-%dT%H:%M:%SZ',
             '%Y-%m-%dT%H:%M:%S.%fZ',
         ]
         dt = None
 
-        too_fractional = re.match(r'.*\.\d{6}(\d+)', datetime_str)
+        too_fractional = re.match(r'(.*\.\d{6})(\d+)(Z|[\+|-]\d{1,2}:\d{1,2})', datetime_str)
         if too_fractional:
             # The supplied value contains seven digits in the
             # fractional second part, whereas Python expects
             # a maxium of six, so strip it.
             # https://github.com/Azure/azure-functions-python-worker/issues/269
-            extra_digits = len(too_fractional.group(1))
-            datetime_str = too_fractional.group(0)[:-extra_digits - 1] + 'Z'
+            extra_digits = len(too_fractional.group(2))
+            datetime_str = too_fractional.group(1)[:-extra_digits] + too_fractional.group(3)
 
         for fmt in formats:
             try:

--- a/azure/functions_worker/bindings/meta.py
+++ b/azure/functions_worker/bindings/meta.py
@@ -173,14 +173,14 @@ class _BaseConverter(metaclass=_ConverterMeta, binding=None):
         ]
         dt = None
 
-        too_fractional = re.match(r'.*\.\d{6}(\d+)Z', datetime_str)
+        too_fractional = re.match(r'.*\.\d{6}(\d+)', datetime_str)
         if too_fractional:
             # The supplied value contains seven digits in the
             # fractional second part, whereas Python expects
             # a maxium of six, so strip it.
             # https://github.com/Azure/azure-functions-python-worker/issues/269
             extra_digits = len(too_fractional.group(1))
-            datetime_str = datetime_str[:-extra_digits - 1] + 'Z'
+            datetime_str = too_fractional.group(0)[:-extra_digits - 1] + 'Z'
 
         for fmt in formats:
             try:


### PR DESCRIPTION
When using Queue Storage and triggering manually it would fail with this error:
```
Result: Failure
Exception: ValueError: time data '9999-12-31T23:59:59.9999999+00:00' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
Stack:   File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/azure/functions_worker/dispatcher.py", line 273, in _handle__invocation_request
    pytype=pb_type_info.pytype)
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/azure/functions_worker/bindings/meta.py", line 298, in from_incoming_proto
    trigger_metadata=trigger_metadata)
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/azure/functions_worker/bindings/queue.py", line 93, in from_proto
    trigger_metadata, 'ExpirationTime'),
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/azure/functions_worker/bindings/meta.py", line 149, in _parse_datetime_metadata
    return cls._parse_datetime(datetime_str)
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/azure/functions_worker/bindings/meta.py", line 192, in _parse_datetime
    raise last_error
  File "/home/site/wwwroot/.python_packages/lib/python3.6/site-packages/azure/functions_worker/bindings/meta.py", line 187, in _parse_datetime
    dt = datetime.datetime.strptime(datetime_str, fmt)
  File "/usr/local/lib/python3.6/_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.6/_strptime.py", line 362, in _strptime
    (data_string, format))
```

This is to address the fact that the RegEx would miss certain formats and then wouldn't truncate correctly.
 