### PR TITLE
Add .vscode in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 
 .testconfig
 .pytest_cache
+
+# vscode
+.vscode


### PR DESCRIPTION
When creating the work space in VSCode, it will automatically create a .vscode folder to store the user's setting (remote debug ptvsd etc.).

We may want to keep this folder local to each developers.