### PR TITLE
Clear sys.path cache to import from new folders

### DIFF
--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -10,6 +10,7 @@ import queue
 import threading
 import traceback
 import os
+import sys
 
 import grpc
 import pkg_resources
@@ -363,6 +364,8 @@ class Dispatcher(metaclass=DispatcherMeta):
                         'request ID: %s', self.request_id)
 
             func_env_reload_request = req.function_environment_reload_request
+
+            sys.path_importer_cache.clear()
 
             os.environ.clear()
 

--- a/azure/functions_worker/testutils.py
+++ b/azure/functions_worker/testutils.py
@@ -628,6 +628,16 @@ def start_webhost(*, script_dir=None, stdout=None):
     return _WebHostProxy(proc, addr)
 
 
+def create_dummy_dispatcher():
+    dummy_event_loop = asyncio.new_event_loop()
+    disp = dispatcher.Dispatcher(
+        dummy_event_loop, '127.0.0.1', 0,
+        'test_worker_id', 'test_request_id',
+        1.0, 1000)
+    dummy_event_loop.close()
+    return disp
+
+
 def _remove_path(path):
     if path.is_symlink():
         path.unlink()

--- a/tests/path_import/path_import.py
+++ b/tests/path_import/path_import.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import shutil
+import asyncio
+
+from azure.functions_worker import protos
+from azure.functions_worker import testutils
+
+
+async def verify_path_imports():
+    test_env = {}
+    request = protos.FunctionEnvironmentReloadRequest(
+        environment_variables=test_env)
+
+    request_msg = protos.StreamingMessage(
+        request_id='0',
+        function_environment_reload_request=request)
+
+    disp = testutils.create_dummy_dispatcher()
+
+    test_path = 'test_module_dir'
+    test_mod_path = os.path.join(test_path, 'test_module.py')
+
+    os.mkdir(test_path)
+    with open(test_mod_path, 'w') as f:
+        f.write('CONSTANT = "This module was imported!"')
+
+    if (sys.argv[1] == 'success'):
+        await disp._handle__function_environment_reload_request(request_msg)
+
+    try:
+        import test_module
+        print(test_module.CONSTANT)
+    finally:
+        # Cleanup
+        shutil.rmtree(test_path)
+
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(verify_path_imports())
+    loop.close()

--- a/tests/path_import/test_path_import.sh
+++ b/tests/path_import/test_path_import.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+# $2 is sys.path from caller
+export PYTHONPATH="test_module_dir:$2"
+SCRIPT_DIR="$(dirname $0)"
+
+if [ "$1" = "fail" ]
+    then
+        python $SCRIPT_DIR/path_import.py 'fail'
+else
+    python $SCRIPT_DIR/path_import.py 'success'
+fi
+
+unset PYTHONPATH

--- a/tests/path_import/test_path_import.sh
+++ b/tests/path_import/test_path_import.sh
@@ -4,11 +4,6 @@
 export PYTHONPATH="test_module_dir:$2"
 SCRIPT_DIR="$(dirname $0)"
 
-if [ "$1" = "fail" ]
-    then
-        python $SCRIPT_DIR/path_import.py 'fail'
-else
-    python $SCRIPT_DIR/path_import.py 'success'
-fi
+python $SCRIPT_DIR/path_import.py $1
 
 unset PYTHONPATH

--- a/tests/test_rpc_messages.py
+++ b/tests/test_rpc_messages.py
@@ -1,15 +1,19 @@
 import os
-import asyncio
+import subprocess
+import sys
 
 from azure.functions_worker import protos
-from azure.functions_worker import dispatcher
 from azure.functions_worker import testutils
 
 
 class TestGRPC(testutils.AsyncTestCase):
     pre_test_env = os.environ.copy()
 
-    async def _handle_environment_reload_request(self, test_env):
+    def _reset_environ(self):
+        for key, value in self.pre_test_env.items():
+            os.environ[key] = value
+
+    async def _verify_environment_reloaded(self, test_env):
             request = protos.FunctionEnvironmentReloadRequest(
                 environment_variables=test_env)
 
@@ -17,12 +21,7 @@ class TestGRPC(testutils.AsyncTestCase):
                 request_id='0',
                 function_environment_reload_request=request)
 
-            dummy_event_loop = asyncio.new_event_loop()
-            disp = dispatcher.Dispatcher(
-                dummy_event_loop, '127.0.0.1', 0,
-                'test_worker_id', 'test_request_id',
-                1.0, 1000)
-            dummy_event_loop.close()
+            disp = testutils.create_dummy_dispatcher()
 
             try:
                 r = await disp._handle__function_environment_reload_request(
@@ -33,16 +32,41 @@ class TestGRPC(testutils.AsyncTestCase):
                 status = r.function_environment_reload_response.result.status
                 self.assertEqual(status, protos.StatusResult.Success)
             finally:
-                self.reset_environ()
+                self._reset_environ()
 
     async def test_multiple_env_vars_load(self):
         test_env = {'TEST_KEY': 'foo', 'HELLO': 'world'}
-        await self._handle_environment_reload_request(test_env)
+        await self._verify_environment_reloaded(test_env)
 
     async def test_empty_env_vars_load(self):
         test_env = {}
-        await self._handle_environment_reload_request(test_env)
+        await self._verify_environment_reloaded(test_env)
 
-    def reset_environ(self):
-        for key, value in self.pre_test_env.items():
-            os.environ[key] = value
+    def _verify_sys_path_import(self, result, expected_output):
+        try:
+            test_dir = os.path.dirname(os.path.realpath(__file__))
+            path_import_script = os.path.join(
+                test_dir,
+                'path_import',
+                'test_path_import.sh')
+
+            subprocess.run(['chmod +x ' + path_import_script], shell=True)
+
+            exported_path = ":".join(sys.path)
+            output = subprocess.check_output(
+                [path_import_script, result, exported_path],
+                stderr=subprocess.STDOUT)
+            decoded_output = output.decode(sys.stdout.encoding).strip()
+            self.assertTrue(expected_output in decoded_output)
+        finally:
+            self._reset_environ()
+
+    def test_failed_sys_path_import(self):
+        self._verify_sys_path_import(
+            'fail',
+            "No module named 'test_module'")
+
+    def test_successful_sys_path_import(self):
+        self._verify_sys_path_import(
+            'success',
+            'This module was imported!')


### PR DESCRIPTION
We need to clear `sys.path` cache to allow for reloading of modules from directories that are created after we start the host (i.e. during specialization). 