### PR TITLE
Allow json data type for generic table binding

### DIFF
--- a/azure/functions_worker/bindings/generic.py
+++ b/azure/functions_worker/bindings/generic.py
@@ -37,6 +37,8 @@ class GenericBinding:
             result = data.value
         elif data_type == 'bytes':
             result = data.value
+        elif data_type == 'json':
+            result = data.value
         else:
             raise ValueError(
                 f'unexpected type of data received for the "generic" binding '

--- a/tests/table_functions/table_in_binding/__init__.py
+++ b/tests/table_functions/table_in_binding/__init__.py
@@ -1,0 +1,8 @@
+import json
+
+import azure.functions as func
+
+
+def main(req: func.HttpRequest, testEntity):
+    headers_dict = json.loads(testEntity)
+    return func.HttpResponse(status_code=200, headers=headers_dict)

--- a/tests/table_functions/table_in_binding/function.json
+++ b/tests/table_functions/table_in_binding/function.json
@@ -1,0 +1,28 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "authLevel": "anonymous",
+      "methods": [
+        "get"
+      ],
+      "name": "req"
+    },
+    {
+      "direction": "in",
+      "type": "table",
+      "name": "testEntity",
+      "partitionKey": "test",
+      "rowKey": "WillBePopulatedWithGuid",
+      "tableName": "BindingTestTable",
+      "connection": "AzureWebJobsStorage"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/table_functions/table_out_binding/__init__.py
+++ b/tests/table_functions/table_out_binding/__init__.py
@@ -1,0 +1,13 @@
+import json
+import uuid
+
+import azure.functions as func
+
+
+def main(req: func.HttpRequest, resp: func.Out[func.HttpResponse]):
+    row_key_uuid = str(uuid.uuid4())
+    table_dict = {'PartitionKey': 'test', 'RowKey': row_key_uuid}
+    table_json = json.dumps(table_dict)
+    http_resp = func.HttpResponse(status_code=200, headers=table_dict)
+    resp.set(http_resp)
+    return table_json

--- a/tests/table_functions/table_out_binding/function.json
+++ b/tests/table_functions/table_out_binding/function.json
@@ -1,0 +1,24 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "authLevel": "anonymous",
+      "methods": ["post"],
+      "name": "req"
+    },
+    {
+      "direction": "out",
+      "type": "table",
+      "name": "$return",
+      "tableName": "BindingTestTable",
+      "connection": "AzureWebJobsStorage"
+    },
+    {
+      "name": "resp",
+      "type": "http",
+      "direction": "out"
+    }
+  ]
+}

--- a/tests/test_table_functions.py
+++ b/tests/test_table_functions.py
@@ -1,0 +1,36 @@
+import json
+import pathlib
+import time
+
+from azure.functions_worker import testutils
+
+
+class TestTableFunctions(testutils.WebHostTestCase):
+
+    @classmethod
+    def get_script_dir(cls):
+        return 'table_functions'
+
+    def test_table_bindings(self):
+        out_resp = self.webhost.request('POST', 'table_out_binding')
+        self.assertEqual(out_resp.status_code, 200)
+        row_key = out_resp.headers['rowKey']
+
+        script_dir = pathlib.Path(self.get_script_dir())
+        json_path = pathlib.Path('table_in_binding/function.json')
+        full_json_path = testutils.TESTS_ROOT / script_dir / json_path
+        # Dynamically rewrite function.json to point to new row key
+        with open(full_json_path, 'r') as f:
+            func_dict = json.load(f)
+            func_dict['bindings'][1]['rowKey'] = row_key
+
+        with open(full_json_path, 'w') as f:
+            json.dump(func_dict, f, indent=2)
+
+        # wait for host to restart after change
+        time.sleep(1)
+
+        in_resp = self.webhost.request('GET', 'table_in_binding')
+        self.assertEqual(in_resp.status_code, 200)
+        in_row_key = in_resp.headers['rowKey']
+        self.assertEqual(in_row_key, row_key)


### PR DESCRIPTION
Needed to enable https://github.com/Azure/azure-functions-python-worker/issues/448. Also applicable for any other binding that only supports `json`. The WebJobs SDK returns the table binding as a `json` (it cannot currently handle `string` or `binary`). 