### PR TITLE
Add ModuleNotFound exception trace handler

### DIFF
--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -8,7 +8,6 @@ import concurrent.futures
 import logging
 import queue
 import threading
-import traceback
 import os
 import sys
 
@@ -22,6 +21,7 @@ from . import protos
 from . import constants
 
 from .logging import error_logger, logger
+from .tracing import marshall_exception_trace
 
 
 class DispatcherMeta(type):
@@ -188,7 +188,7 @@ class Dispatcher(metaclass=DispatcherMeta):
                        f'Could not serialize original exception message.')
 
         try:
-            stack_trace = ''.join(traceback.format_tb(exc.__traceback__))
+            stack_trace = marshall_exception_trace(exc)
         except Exception:
             stack_trace = ''
 

--- a/azure/functions_worker/tracing.py
+++ b/azure/functions_worker/tracing.py
@@ -1,0 +1,30 @@
+from typing import List
+import traceback
+
+
+def marshall_exception_trace(exc: Exception) -> str:
+    stack_summary: traceback.StackSummary = traceback.extract_tb(
+        exc.__traceback__)
+    if isinstance(exc, ModuleNotFoundError):
+        stack_summary = _marshall_module_not_found_error(stack_summary)
+    return ''.join(stack_summary.format())
+
+
+def _marshall_module_not_found_error(
+    tbss: traceback.StackSummary
+) -> traceback.StackSummary:
+    tbss = _remove_frame_from_stack(tbss, '<frozen importlib._bootstrap>')
+    tbss = _remove_frame_from_stack(
+        tbss, '<frozen importlib._bootstrap_external>')
+    return tbss
+
+
+def _remove_frame_from_stack(
+    tbss: traceback.StackSummary,
+    framename: str
+) -> traceback.StackSummary:
+    filtered_stack_list: List[traceback.FrameSummary] = list(
+        filter(lambda frame: getattr(frame, 'filename') != framename, tbss))
+    filtered_stack: traceback.StackSummary = traceback.StackSummary.from_list(
+        filtered_stack_list)
+    return filtered_stack

--- a/tests/test_broken_functions.py
+++ b/tests/test_broken_functions.py
@@ -134,6 +134,10 @@ class TestMockHost(testutils.AsyncTestCase):
 
             self.assertIn('ImportError',
                           r.response.result.exception.message)
+            self.assertNotIn('<frozen importlib._bootstrap>',
+                             r.response.result.exception.message)
+            self.assertNotIn('<frozen importlib._bootstrap_external>',
+                             r.response.result.exception.message)
 
     async def test_load_broken__inout_param(self):
         async with testutils.start_mockhost(


### PR DESCRIPTION
### Related Issue
Fixes https://github.com/Azure/azure-functions-python-worker/issues/273

### Solution
I implement an stackframe filter to suppress the error message from python "importlib":
1. The exception traceback will be extracted into a [StackSummary](https://docs.python.org/3/library/traceback.html#traceback.StackSummary)
2. Filter out unnecessary **<frozen importlib._bootstrap>** and **<frozen importlib._bootstrap_external>** according to @elprans cpython [reference](https://github.com/python/cpython/blob/0f4e8132820947d93eccf31b9e526b81c6ffa53d/Python/import.c#L1484)
3. Format the modified StackSummary

### CR Request
@maiqbal11