### PR TITLE
Fix nested namespace module import issue

### DIFF
--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -375,9 +375,10 @@ class Dispatcher(metaclass=DispatcherMeta):
             for var in env_vars:
                 os.environ[var] = env_vars[var]
 
-            if sys.modules.get('azure'):
-                importlib.reload(sys.modules['azure'])
-                logger.info('Reloading azure module')
+            importlib.invalidate_caches()
+
+            for module in sys.modules.values():
+                importlib.reload(module)
 
             success_response = protos.FunctionEnvironmentReloadResponse(
                 result=protos.StatusResult(

--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -375,10 +375,8 @@ class Dispatcher(metaclass=DispatcherMeta):
             for var in env_vars:
                 os.environ[var] = env_vars[var]
 
-            importlib.invalidate_caches()
-
-            if sys.modules.get('azure'):
-                importlib.reload(sys.modules['azure'])
+            # Reload azure namespace for customer's libraries
+            importlib.reload(sys.modules['azure'])
 
             success_response = protos.FunctionEnvironmentReloadResponse(
                 result=protos.StatusResult(

--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -377,8 +377,8 @@ class Dispatcher(metaclass=DispatcherMeta):
 
             importlib.invalidate_caches()
 
-            for module in sys.modules.values():
-                importlib.reload(module)
+            if sys.modules.get('azure'):
+                importlib.reload(sys.modules['azure'])
 
             success_response = protos.FunctionEnvironmentReloadResponse(
                 result=protos.StatusResult(

--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -10,6 +10,7 @@ import queue
 import threading
 import os
 import sys
+import importlib
 
 import grpc
 import pkg_resources
@@ -373,6 +374,8 @@ class Dispatcher(metaclass=DispatcherMeta):
 
             for var in env_vars:
                 os.environ[var] = env_vars[var]
+
+            importlib.invalidate_caches()
 
             success_response = protos.FunctionEnvironmentReloadResponse(
                 result=protos.StatusResult(

--- a/azure/functions_worker/dispatcher.py
+++ b/azure/functions_worker/dispatcher.py
@@ -375,7 +375,9 @@ class Dispatcher(metaclass=DispatcherMeta):
             for var in env_vars:
                 os.environ[var] = env_vars[var]
 
-            importlib.invalidate_caches()
+            if sys.modules.get('azure'):
+                importlib.reload(sys.modules['azure'])
+                logger.info('Reloading azure module')
 
             success_response = protos.FunctionEnvironmentReloadResponse(
                 result=protos.StatusResult(


### PR DESCRIPTION
This is related to running a function app with nested namespace library (e.g. azure.storage)
Repository is [here](https://github.com/jeffhollan/google-tensorflow-sample).

When we specialize the python worker from placeholder mode, we need to
1. invalidate the finder's cache.
2. reload the module to resolve the second level namespace.

Otherwise, the module will not be recognized.
