### PR TITLE
Pass bytes from invocation request metadata

### DIFF
--- a/azure-pipelines-e2e.yml
+++ b/azure-pipelines-e2e.yml
@@ -1,7 +1,7 @@
 name: 1.0.0-beta$(Date:yyyyMMdd)$(Rev:.r)
 
 variables:
-    DOTNET_VERSION: '2.2.300'
+    DOTNET_VERSION: '2.2.402'
     CORE_TOOLS_EXE_PATH: '$(Build.SourcesDirectory)/Azure.Functions.Core.Tools/func'
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(pythonVersion)'
-      addToPath: true 
+      addToPath: true
   - powershell:
       .ci/e2e/setup-e2e.ps1
     displayName: 'Setup custom Core Tools'
@@ -31,9 +31,9 @@ jobs:
     displayName: 'Install Core Tools production'
   - task: DotNetCoreInstaller@0
     inputs:
-      packageType: 'sdk' 
+      packageType: 'sdk'
       version: $(DOTNET_VERSION)
-    displayName: 'Install dotnet' 
+    displayName: 'Install dotnet'
   - bash: |
         set -e -x
         python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple -U -e .[dev]
@@ -55,4 +55,3 @@ jobs:
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'test_result'
-      

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ trigger:
 - master
 
 variables:
-    DOTNET_VERSION: '2.2.401'
+    DOTNET_VERSION: '2.2.402'
 
 jobs:
 - job: Tests
@@ -22,7 +22,7 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(pythonVersion)'
-      addToPath: true 
+      addToPath: true
   - task: ShellScript@2
     inputs:
       disableAutoCwd: true # Execute in current directory
@@ -30,12 +30,12 @@ jobs:
     displayName: 'Install Core Tools'
   - task: DotNetCoreInstaller@0
     inputs:
-      packageType: 'sdk' 
+      packageType: 'sdk'
       version: $(DOTNET_VERSION)
-    displayName: 'Install dotnet' 
+    displayName: 'Install dotnet'
   - task: ShellScript@2
     inputs:
-      disableAutoCwd: true 
+      disableAutoCwd: true
       scriptPath: .ci/linux_devops_build.sh
     displayName: 'Build'
   - bash: |
@@ -51,7 +51,7 @@ jobs:
       LINUXEVENTHUBCONNECTIONSTRING: $(LinuxEventHubConnectionString)
       LINUXSERVICEBUSCONNECTIONSTRING: $(LinuxServiceBusConnectionString)
     displayName: 'E2E Tests'
-  
+
 - template: pack/templates/win_env_gen.yml
   parameters:
     jobName: 'WindowsEnvGen'
@@ -83,10 +83,10 @@ jobs:
              ]
   pool:
       vmImage: 'vs2017-win2016'
-  steps: 
+  steps:
   - task: DownloadBuildArtifacts@0
     inputs:
-      buildType: 'current' 
+      buildType: 'current'
       downloadType: 'specific'
       downloadPath: '$(Build.SourcesDirectory)'
   - task: NuGetCommand@2
@@ -99,4 +99,3 @@ jobs:
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'PythonWorkerRunEnvironments'
-      

--- a/azure_functions_worker/bindings/datumdef.py
+++ b/azure_functions_worker/bindings/datumdef.py
@@ -33,7 +33,7 @@ class Datum:
                     k: Datum(v, 'string') for k, v in http.headers.items()
                 },
                 body=(
-                    Datum.from_typed_data(http.rawBody)
+                    Datum.from_typed_data(http.body)
                     or Datum(type='bytes', value=b'')
                 ),
                 params={

--- a/azure_functions_worker/constants.py
+++ b/azure_functions_worker/constants.py
@@ -1,3 +1,5 @@
 # Capabilities
 RAW_HTTP_BODY_BYTES = "RawHttpBodyBytes"
 TYPED_DATA_COLLECTION = "TypedDataCollection"
+RPC_HTTP_BODY_ONLY = "RpcHttpBodyOnly"
+RPC_HTTP_TRIGGER_METADATA_REMOVED = "RpcHttpTriggerMetadataRemoved"

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -217,6 +217,8 @@ class Dispatcher(metaclass=DispatcherMeta):
         capabilities = dict()
         capabilities[constants.RAW_HTTP_BODY_BYTES] = "true"
         capabilities[constants.TYPED_DATA_COLLECTION] = "true"
+        capabilities[constants.RPC_HTTP_BODY_ONLY] = "true"
+        capabilities[constants.RPC_HTTP_TRIGGER_METADATA_REMOVED] = "true"
 
         return protos.StreamingMessage(
             request_id=self.request_id,

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@ from setuptools.command import develop
 
 
 # TODO: change this to something more stable when available.
-WEBHOST_URL = ('https://ci.appveyor.com/api/buildjobs/sfelyng3x6p5sus0'
+WEBHOST_URL = ('https://ci.appveyor.com/api/buildjobs/j7r6pk8p7mqxyuuw'
                '/artifacts'
-               '/Functions.Binaries.2.0.12642.no-runtime.zip')
+               '/Functions.Binaries.2.0.12701.no-runtime.zip')
 
 # Extensions necessary for non-core bindings.
 AZURE_EXTENSIONS = [

--- a/tests/unittests/test_http_functions.py
+++ b/tests/unittests/test_http_functions.py
@@ -213,3 +213,51 @@ class TestHttpFunctions(testutils.WebHostTestCase):
         finally:
             if (os.path.exists(received_img_file)):
                 os.remove(received_img_file)
+
+    def test_image_png_content_type(self):
+        parent_dir = pathlib.Path(__file__).parent
+        image_file = parent_dir / 'resources/functions.png'
+        with open(image_file, 'rb') as image:
+            img = image.read()
+            img_len = len(img)
+            r = self.webhost.request(
+                'POST', 'raw_body_bytes',
+                headers={'Content-Type': 'image/png'},
+                data=img)
+
+        received_body_len = int(r.headers['body-len'])
+        self.assertEqual(received_body_len, img_len)
+
+        body = r.content
+        try:
+            received_img_file = parent_dir / 'received_img.png'
+            with open(received_img_file, 'wb') as received_img:
+                received_img.write(body)
+            self.assertTrue(filecmp.cmp(received_img_file, image_file))
+        finally:
+            if (os.path.exists(received_img_file)):
+                os.remove(received_img_file)
+
+    def test_application_octet_stream_content_type(self):
+        parent_dir = pathlib.Path(__file__).parent
+        image_file = parent_dir / 'resources/functions.png'
+        with open(image_file, 'rb') as image:
+            img = image.read()
+            img_len = len(img)
+            r = self.webhost.request(
+                'POST', 'raw_body_bytes',
+                headers={'Content-Type': 'application/octet-stream'},
+                data=img)
+
+        received_body_len = int(r.headers['body-len'])
+        self.assertEqual(received_body_len, img_len)
+
+        body = r.content
+        try:
+            received_img_file = parent_dir / 'received_img.png'
+            with open(received_img_file, 'wb') as received_img:
+                received_img.write(body)
+            self.assertTrue(filecmp.cmp(received_img_file, image_file))
+        finally:
+            if (os.path.exists(received_img_file)):
+                os.remove(received_img_file)


### PR DESCRIPTION
Fix a bug https://github.com/Azure/azure-functions-python-worker/issues/519
1. Forbid host from sending duplicated body bytes data in [input_data, http.rawBody, trigger metadata].
2. Reconstruct http body from input_data.
3. Conversion by content type on [host](https://github.com/Azure/azure-functions-host/blob/96fe7f8fae29f859e4a7d3b40cc6d9c9c3f25d81/src/WebJobs.Script/OutOfProc/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs#L235)

Discussed with @yojagad @pragnagopa
