### PR TITLE
Fix single event e2e tests in eventhub 

### DIFF
--- a/tests/endtoend/eventhub_functions/eventhub_output/function.json
+++ b/tests/endtoend/eventhub_functions/eventhub_output/function.json
@@ -11,7 +11,7 @@
       "type": "eventHub",
       "name": "event",
       "direction": "out",
-      "eventHubName": "python-worker-ci",
+      "eventHubName": "python-worker-ci-eventhub-one",
       "connection": "AzureWebJobsEventHubConnectionString"
     },
     {

--- a/tests/endtoend/eventhub_functions/eventhub_trigger/function.json
+++ b/tests/endtoend/eventhub_functions/eventhub_trigger/function.json
@@ -6,7 +6,7 @@
       "type": "eventHubTrigger",
       "name": "event",
       "direction": "in",
-      "eventHubName": "python-worker-eventhub-ci-linux",
+      "eventHubName": "python-worker-ci-eventhub-one",
       "connection": "AzureWebJobsEventHubConnectionString"
     },
     {

--- a/tests/endtoend/test_eventhub_functions.py
+++ b/tests/endtoend/test_eventhub_functions.py
@@ -20,24 +20,12 @@ class TestEventHubFunctions(testutils.WebHostTestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'OK')
 
-        max_retries = 30
+        # Allow trigger to fire.
+        time.sleep(5)
 
-        for try_no in range(max_retries):
-            # Allow trigger to fire.
-            time.sleep(2)
+        # Check that the trigger has fired.
+        r = self.webhost.request('GET', 'get_eventhub_triggered')
+        self.assertEqual(r.status_code, 200)
+        response = r.json()
 
-            try:
-                # Check that the trigger has fired.
-                r = self.webhost.request('GET', 'get_eventhub_triggered')
-                self.assertEqual(r.status_code, 200)
-                response = r.json()
-
-                self.assertEqual(
-                    response,
-                    doc
-                )
-            except AssertionError as e:
-                if try_no == max_retries - 1:
-                    raise
-            else:
-                break
+        self.assertEqual(response, doc)


### PR DESCRIPTION
The send/receive event hub name should be the same when running e2e tests