### PR TITLE
Add durable functions support

### DIFF
--- a/azure_functions_worker/bindings/__init__.py
+++ b/azure_functions_worker/bindings/__init__.py
@@ -2,6 +2,7 @@ from .tracecontext import TraceContext
 from .context import Context
 from .meta import check_input_type_annotation
 from .meta import check_output_type_annotation
+from .meta import has_implicit_output
 from .meta import is_trigger_binding
 from .meta import from_incoming_proto, to_outgoing_proto
 from .out import Out
@@ -11,5 +12,6 @@ __all__ = (
     'Out', 'Context',
     'is_trigger_binding',
     'check_input_type_annotation', 'check_output_type_annotation',
+    'has_implicit_output',
     'from_incoming_proto', 'to_outgoing_proto', 'TraceContext',
 )

--- a/azure_functions_worker/bindings/generic.py
+++ b/azure_functions_worker/bindings/generic.py
@@ -46,3 +46,7 @@ class GenericBinding:
             )
 
         return result
+
+    @classmethod
+    def has_implicit_output(cls) -> bool:
+        return False

--- a/azure_functions_worker/bindings/meta.py
+++ b/azure_functions_worker/bindings/meta.py
@@ -10,15 +10,11 @@ from . import generic
 def get_binding_registry():
     func = sys.modules.get('azure.functions')
 
-    if func is not None:
-        return func.get_binding_registry()
-
-    try:
+    # If fails to acquire customer's BYO azure-functions, load the builtin
+    if func is None:
         import azure.functions as func
-        return func.get_binding_registry()
-    except ImportError:
-        return None
-    return None
+
+    return func.get_binding_registry()
 
 
 def get_binding(bind_name: str) -> object:

--- a/azure_functions_worker/bindings/meta.py
+++ b/azure_functions_worker/bindings/meta.py
@@ -9,6 +9,7 @@ from . import generic
 
 def get_binding_registry():
     func = sys.modules.get('azure.functions')
+
     if func is not None:
         return func.get_binding_registry()
     else:
@@ -20,7 +21,6 @@ def get_binding(bind_name: str) -> object:
     registry = get_binding_registry()
     if registry is not None:
         binding = registry.get(bind_name)
-
     if binding is None:
         binding = generic.GenericBinding
 
@@ -32,14 +32,22 @@ def is_trigger_binding(bind_name: str) -> bool:
     return binding.has_trigger_support()
 
 
-def check_input_type_annotation(binding: str, pytype: type) -> bool:
-    binding = get_binding(binding)
+def check_input_type_annotation(bind_name: str, pytype: type) -> bool:
+    binding = get_binding(bind_name)
     return binding.check_input_type_annotation(pytype)
 
 
-def check_output_type_annotation(binding: str, pytype: type) -> bool:
-    binding = get_binding(binding)
+def check_output_type_annotation(bind_name: str, pytype: type) -> bool:
+    binding = get_binding(bind_name)
     return binding.check_output_type_annotation(pytype)
+
+
+def has_implicit_output(bind_name: str) -> bool:
+    binding = get_binding(bind_name)
+
+    # If the binding does not have metaclass of meta.InConverter
+    # The implicit_output does not exist
+    return getattr(binding, 'has_implicit_output', lambda: False)()
 
 
 def from_incoming_proto(

--- a/azure_functions_worker/bindings/meta.py
+++ b/azure_functions_worker/bindings/meta.py
@@ -12,8 +12,13 @@ def get_binding_registry():
 
     if func is not None:
         return func.get_binding_registry()
-    else:
+
+    try:
+        import azure.functions as func
+        return func.get_binding_registry()
+    except ImportError:
         return None
+    return None
 
 
 def get_binding(bind_name: str) -> object:

--- a/azure_functions_worker/bindings/meta.py
+++ b/azure_functions_worker/bindings/meta.py
@@ -12,13 +12,8 @@ def get_binding_registry():
 
     if func is not None:
         return func.get_binding_registry()
-
-    try:
-        import azure.functions as func
-        return func.get_binding_registry()
-    except ImportError:
+    else:
         return None
-    return None
 
 
 def get_binding(bind_name: str) -> object:

--- a/azure_functions_worker/functions.py
+++ b/azure_functions_worker/functions.py
@@ -82,6 +82,13 @@ class Registry:
                 assert return_binding_name is not None
 
                 has_return = True
+            elif bindings.has_implicit_output(desc.type):
+                # If the binding specify implicit output binding
+                # (e.g. orchestrationTrigger, activityTrigger)
+                # we should enable output even if $return is not specified
+                has_return = True
+                return_binding_name = f'{desc.type}_ret'
+                bound_params[name] = desc
             else:
                 bound_params[name] = desc
 
@@ -180,7 +187,8 @@ class Registry:
                     f'direction in function.json, but its annotation '
                     f'is azure.functions.Out in Python')
 
-            if param_has_anno and param_py_type in (str, bytes):
+            if param_has_anno and param_py_type in (str, bytes) and (
+                    not bindings.has_implicit_output(desc.type)):
                 param_bind_type = 'generic'
             else:
                 param_bind_type = desc.type

--- a/setup.py
+++ b/setup.py
@@ -279,7 +279,7 @@ setup(
     ],
     extras_require={
         'dev': [
-            'azure-functions==1.1.0',
+            'azure-functions==1.2.0b1',
             'flake8~=3.7.9',
             'mypy',
             'pytest',


### PR DESCRIPTION
### Background
We want to enable durable functions in Azure Functions Python Worker.
Previously, we are blocked by the implicit return from the generic binding.
The solution in this PR is to define a rich binding for OrchestrationTrigger and allow implicit returns from the trigger.

### Depends On
https://github.com/Azure/azure-functions-python-library/pull/48
CI is failing due to dependencies on azure-functions-python-library

### Resolves
resolves: https://github.com/Azure/azure-functions-python-worker/issues/608
resolves: https://github.com/Azure/azure-functions-python-worker/issues/227

### Usage
```javascript
// function.json
{
  "scriptFile": "__init__.py",
  "bindings": [
    {
      "name": "orctx",
      "type": "orchestrationTrigger",
      "direction": "in"
    }
  ],
  "disabled": false
}
```

```python
# main.py
def main(orctx: func.OrchestrationContext):
    orchestrate = df.Orchestrator.create(generator_function)
    result = orchestrate(orctx.body)
    return result
```