### PR TITLE
Add unittests for generic bindings and durable functions

### DIFF
--- a/tests/unittests/durable_functions/activity_trigger/function.json
+++ b/tests/unittests/durable_functions/activity_trigger/function.json
@@ -1,0 +1,10 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+      {
+        "type": "activityTrigger",
+        "name": "input",
+        "direction": "in"
+      }
+    ]
+  }

--- a/tests/unittests/durable_functions/activity_trigger/main.py
+++ b/tests/unittests/durable_functions/activity_trigger/main.py
@@ -1,0 +1,2 @@
+def main(input: str):
+    return input

--- a/tests/unittests/durable_functions/activity_trigger/main.py
+++ b/tests/unittests/durable_functions/activity_trigger/main.py
@@ -1,2 +1,2 @@
-def main(input: str):
+def main(input: str) -> str:
     return input

--- a/tests/unittests/durable_functions/activity_trigger_no_anno/function.json
+++ b/tests/unittests/durable_functions/activity_trigger_no_anno/function.json
@@ -1,0 +1,10 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+      {
+        "type": "activityTrigger",
+        "name": "input",
+        "direction": "in"
+      }
+    ]
+  }

--- a/tests/unittests/durable_functions/activity_trigger_no_anno/main.py
+++ b/tests/unittests/durable_functions/activity_trigger_no_anno/main.py
@@ -1,0 +1,2 @@
+def main(input):
+    return input

--- a/tests/unittests/durable_functions/orchestration_trigger/function.json
+++ b/tests/unittests/durable_functions/orchestration_trigger/function.json
@@ -1,0 +1,10 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+      {
+        "type": "orchestrationTrigger",
+        "name": "context",
+        "direction": "in"
+      }
+    ]
+  }

--- a/tests/unittests/durable_functions/orchestration_trigger/main.py
+++ b/tests/unittests/durable_functions/orchestration_trigger/main.py
@@ -1,0 +1,13 @@
+# import azure.durable_functions as df
+
+
+def generator_function(context):
+    final_result = yield context.call_activity('activity_trigger', 'foobar')
+    return final_result
+
+
+def main(context):
+    # orchestrate = df.Orchestrator.create(generator_function)
+    # result = orchestrate(context)
+    # return result
+    return f'{context} :)'

--- a/tests/unittests/generic_functions/foobar_as_bytes_no_anno/function.json
+++ b/tests/unittests/generic_functions/foobar_as_bytes_no_anno/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "bindings": [
+    {
+      "type": "foobar",
+      "name": "input",
+      "direction": "in",
+      "dataType": "binary"
+    },
+    {
+      "direction": "out",
+      "name": "$return",
+      "type": "foobar",
+      "dataType": "binary"
+    }
+  ]
+}

--- a/tests/unittests/generic_functions/foobar_as_bytes_no_anno/main.py
+++ b/tests/unittests/generic_functions/foobar_as_bytes_no_anno/main.py
@@ -1,0 +1,3 @@
+# Input as bytes, without annotation
+def main(input):
+    return input

--- a/tests/unittests/generic_functions/foobar_as_str_no_anno/function.json
+++ b/tests/unittests/generic_functions/foobar_as_str_no_anno/function.json
@@ -1,0 +1,17 @@
+{
+  "scriptFile": "main.py",
+  "bindings": [
+    {
+      "type": "foobar",
+      "name": "input",
+      "direction": "in",
+      "dataType": "string"
+    },
+    {
+      "direction": "out",
+      "name": "$return",
+      "type": "foobar",
+      "dataType": "string"
+    }
+  ]
+}

--- a/tests/unittests/generic_functions/foobar_as_str_no_anno/main.py
+++ b/tests/unittests/generic_functions/foobar_as_str_no_anno/main.py
@@ -1,0 +1,3 @@
+# Input as string, without annotation
+def main(input):
+    return input

--- a/tests/unittests/generic_functions/foobar_implicit_output/function.json
+++ b/tests/unittests/generic_functions/foobar_implicit_output/function.json
@@ -1,0 +1,11 @@
+{
+  "scriptFile": "main.py",
+  "bindings": [
+    {
+      "type": "foobar",
+      "name": "input",
+      "direction": "in",
+      "dataType": "string"
+    }
+  ]
+}

--- a/tests/unittests/generic_functions/foobar_implicit_output/main.py
+++ b/tests/unittests/generic_functions/foobar_implicit_output/main.py
@@ -1,0 +1,3 @@
+# Input as string, without annotation
+def main(input: str):
+    return input

--- a/tests/unittests/generic_functions/foobar_with_no_datatype/function.json
+++ b/tests/unittests/generic_functions/foobar_with_no_datatype/function.json
@@ -1,0 +1,10 @@
+{
+  "scriptFile": "main.py",
+  "bindings": [
+    {
+      "type": "foobar",
+      "name": "input",
+      "direction": "in"
+    }
+  ]
+}

--- a/tests/unittests/generic_functions/foobar_with_no_datatype/main.py
+++ b/tests/unittests/generic_functions/foobar_with_no_datatype/main.py
@@ -1,0 +1,2 @@
+def main(input: str) -> str:
+    return input

--- a/tests/unittests/test_mock_durable_functions.py
+++ b/tests/unittests/test_mock_durable_functions.py
@@ -1,0 +1,60 @@
+from azure_functions_worker import protos
+from azure_functions_worker import testutils
+
+
+class TestDurableFunctions(testutils.AsyncTestCase):
+    durable_functions_dir = testutils.UNIT_TESTS_FOLDER / 'durable_functions'
+
+    async def test_mock_activity_trigger(self):
+        async with testutils.start_mockhost(
+                script_root=self.durable_functions_dir) as host:
+
+            func_id, r = await host.load_function('activity_trigger')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'activity_trigger', [
+                    protos.ParameterBinding(
+                        name='input',
+                        data=protos.TypedData(
+                            string='test'
+                        )
+                    )
+                ]
+            )
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+            self.assertEqual(
+                r.response.return_value,
+                protos.TypedData(string='test')
+            )
+
+    async def test_mock_orchestration_trigger(self):
+        async with testutils.start_mockhost(
+                script_root=self.durable_functions_dir) as host:
+
+            func_id, r = await host.load_function('orchestration_trigger')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'orchestration_trigger', [
+                    protos.ParameterBinding(
+                        name='context',
+                        data=protos.TypedData(
+                            string='Durable functions coming soon'
+                        )
+                    )
+                ]
+            )
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+            self.assertEqual(
+                r.response.return_value,
+                protos.TypedData(string='Durable functions coming soon :)')
+            )

--- a/tests/unittests/test_mock_durable_functions.py
+++ b/tests/unittests/test_mock_durable_functions.py
@@ -32,6 +32,33 @@ class TestDurableFunctions(testutils.AsyncTestCase):
                 protos.TypedData(string='test')
             )
 
+    async def test_mock_activity_trigger_no_anno(self):
+        async with testutils.start_mockhost(
+                script_root=self.durable_functions_dir) as host:
+
+            func_id, r = await host.load_function('activity_trigger_no_anno')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'activity_trigger_no_anno', [
+                    protos.ParameterBinding(
+                        name='input',
+                        data=protos.TypedData(
+                            bytes=b'\x34\x93\x04\x70'
+                        )
+                    )
+                ]
+            )
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+            self.assertEqual(
+                r.response.return_value,
+                protos.TypedData(bytes=b'\x34\x93\x04\x70')
+            )
+
     async def test_mock_orchestration_trigger(self):
         async with testutils.start_mockhost(
                 script_root=self.durable_functions_dir) as host:

--- a/tests/unittests/test_mock_generic_functions.py
+++ b/tests/unittests/test_mock_generic_functions.py
@@ -58,3 +58,94 @@ class TestGenericFunctions(testutils.AsyncTestCase):
                 r.response.return_value,
                 protos.TypedData(bytes=b'\x00\x01')
             )
+
+    async def test_mock_generic_as_str_no_anno(self):
+        async with testutils.start_mockhost(
+                script_root=self.generic_funcs_dir) as host:
+
+            func_id, r = await host.load_function('foobar_as_str_no_anno')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'foobar_as_str_no_anno', [
+                    protos.ParameterBinding(
+                        name='input',
+                        data=protos.TypedData(
+                            string='test'
+                        )
+                    )
+                ]
+            )
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+            self.assertEqual(
+                r.response.return_value,
+                protos.TypedData(string='test')
+            )
+
+    async def test_mock_generic_as_bytes_no_anno(self):
+        async with testutils.start_mockhost(
+                script_root=self.generic_funcs_dir) as host:
+
+            func_id, r = await host.load_function('foobar_as_bytes_no_anno')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'foobar_as_bytes_no_anno', [
+                    protos.ParameterBinding(
+                        name='input',
+                        data=protos.TypedData(
+                            bytes=b'\x00\x01'
+                        )
+                    )
+                ]
+            )
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+            self.assertEqual(
+                r.response.return_value,
+                protos.TypedData(bytes=b'\x00\x01')
+            )
+
+    async def test_mock_generic_should_not_support_implicit_output(self):
+        async with testutils.start_mockhost(
+                script_root=self.generic_funcs_dir) as host:
+
+            func_id, r = await host.load_function('foobar_implicit_output')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'foobar_as_bytes_no_anno', [
+                    protos.ParameterBinding(
+                        name='input',
+                        data=protos.TypedData(
+                            bytes=b'\x00\x01'
+                        )
+                    )
+                ]
+            )
+            # It should fail here, since generic binding requires
+            # $return statement in function.json to pass output
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Failure)
+
+    async def test_mock_generic_should_support_without_datatype(self):
+        async with testutils.start_mockhost(
+                script_root=self.generic_funcs_dir) as host:
+
+            # It should fail here, since the generic binding requires datatype
+            # to be defined in function.json
+            func_id, r = await host.load_function('foobar_with_no_datatype')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)

--- a/tests/unittests/test_mock_generic_functions.py
+++ b/tests/unittests/test_mock_generic_functions.py
@@ -142,10 +142,23 @@ class TestGenericFunctions(testutils.AsyncTestCase):
         async with testutils.start_mockhost(
                 script_root=self.generic_funcs_dir) as host:
 
-            # It should fail here, since the generic binding requires datatype
-            # to be defined in function.json
             func_id, r = await host.load_function('foobar_with_no_datatype')
 
             self.assertEqual(r.response.function_id, func_id)
             self.assertEqual(r.response.result.status,
                              protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'foobar_with_no_datatype', [
+                    protos.ParameterBinding(
+                        name='input',
+                        data=protos.TypedData(
+                            bytes=b'\x00\x01'
+                        )
+                    )
+                ]
+            )
+            # It should fail here, since the generic binding requires datatype
+            # to be defined in function.json
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Failure)


### PR DESCRIPTION
Waiting for the durable functions library to be released for the full E2E test
1. Testing if the generic binding is working properly when
     a. When function.json **dataType** is set to 'string' or 'bytes'
     b. When function.json **type** has a generic binding name (does not match any of our built-in triggers)
     c. When main.py has proper or no annotation type
2. Ensure durable function's **activityTrigger** and **orchestrationTrigger** does not fall into any of the generic bindings