### PR TITLE
Fix Python Worker NuGet package to match host release version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ name: 1.x.$(Date:yyyyMMdd)$(Rev:r)
 trigger:
 - dev
 - master
+- release/*
 
 variables:
     DOTNET_VERSION: '2.2.207'
@@ -59,6 +60,7 @@ jobs:
 
 - job: Build_WINDOWS_X64
   dependsOn: 'Tests'
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
   pool:
     vmImage: 'windows-2019'
   strategy:
@@ -87,6 +89,7 @@ jobs:
       artifactName: '$(pythonVersion)_WINDOWS_X64'
 - job: Build_WINDOWS_X86
   dependsOn: 'Tests'
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
   pool:
     vmImage: 'windows-2019'
   strategy:
@@ -109,6 +112,7 @@ jobs:
       artifactName: '$(pythonVersion)_WINDOWS_x86'
 - job: Build_LINUX_X64
   dependsOn: 'Tests'
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
   pool:
     vmImage: 'ubuntu-18.04'
   strategy:
@@ -136,6 +140,7 @@ jobs:
       artifactName: '$(pythonVersion)_LINUX_X64'
 - job: Build_OSX_X64
   dependsOn: 'Tests'
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
   pool:
     vmImage: 'macOS-10.15'
   strategy:
@@ -163,29 +168,26 @@ jobs:
       artifactName: '$(pythonVersion)_OSX_X64'
 
 - job: PackageWorkers
-  dependsOn: ['Build_WINDOWS_X64',
-              'Build_WINDOWS_X86',
-              'Build_LINUX_X64',
-              'Build_OSX_X64'
-             ]
+  dependsOn: ['Build_WINDOWS_X64', 'Build_WINDOWS_X86', 'Build_LINUX_X64', 'Build_OSX_X64']
+  condition: startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')
   pool:
-      vmImage: 'windows-2019'
-  strategy:
-    matrix:
-      V2PythonWorker:
-        minorVersion: '0'
-        nuspecPath: 'pack\Microsoft.Azure.Functions.V2.PythonWorker.nuspec'
-      V3PythonWorker:
-        minorVersion: '1'
-        nuspecPath: 'pack\Microsoft.Azure.Functions.V3.PythonWorker.nuspec'
+      vmImage: 'vs2017-win2016'
   steps:
   - bash: |
-      MAJOR=$(echo $BUILD_BUILDNUMBER | cut -d '.' -f1)
-      MINOR=$(minorVersion)
-      PATCH=$(echo $BUILD_BUILDNUMBER | cut -d '.' -f3)
-      echo "##vso[task.setvariable variable=worker_version]$MAJOR.$MINOR.$PATCH"
-      echo "Packaging Python Worker Version $MAJOR.$MINOR.$PATCH"
-    displayName: "Generate Worker Version"
+      echo "Releasing from $BUILD_SOURCEBRANCHNAME"
+
+      if [[ $BUILD_SOURCEBRANCHNAME = 2\.* ]]
+      then
+        NUSPEC="pack\Microsoft.Azure.Functions.V2.PythonWorker.nuspec"
+      elif [[ $BUILD_SOURCEBRANCHNAME = 3\.* ]]
+        NUSPEC="pack\Microsoft.Azure.Functions.V3.PythonWorker.nuspec"
+      else
+        echo "No Matching Release Tag For $BUILD_SOURCEBRANCHNAME"
+      fi
+
+      echo "##vso[task.setvariable variable=worker_version]$BUILD_SOURCEBRANCHNAME"
+      echo "##vso[task.setvariable variable=nuspec_path]$NUSPEC"
+    displayName: "Generate Worker NuGet Package for Release $BUILD_SOURCEBRANCHNAME"
   - task: DownloadBuildArtifacts@0
     inputs:
       buildType: 'current'
@@ -194,9 +196,9 @@ jobs:
   - task: NuGetCommand@2
     inputs:
       command: pack
-      packagesToPack: '$(nuspecPath)'
+      packagesToPack: "$NUSPEC_PATH"
       versioningScheme: 'byEnvVar'
-      versionEnvVar: WORKER_VERSION # Replaces version in nuspec
+      versionEnvVar: WORKER_VERSION
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixes Issue https://github.com/Azure/azure-functions-python-worker/issues/629
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

1. This PR fixes the release tag for Python Worker NuGet package release. Currently, the release tag does not match the host release tag [Release Examples](https://azfunc.visualstudio.com/Azure%20Functions%20Python/_release?_a=releases&view=mine&definitionId=1). As per Pragna, we should have a version schema of 2.x.x for v2 function app release and 3.x.x for v3 function app release.
2. After this PR being merged in, we should consider pushing each Python worker release align with the host version to a separate release branch `release/2.0.0` and `release/3.0.0`. This PR modifies the Azure Pipeline to generate the proper NuGet with correct version tags in it.
---

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.
<!-- - [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch. -->

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).