### PR TITLE
Fix grpc size limitation

### DIFF
--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -85,10 +85,10 @@ class Dispatcher(metaclass=DispatcherMeta):
 
     @classmethod
     async def connect(cls, host, port, worker_id, request_id,
-                      connect_timeout, max_msg_len=None):
+                      connect_timeout):
         loop = asyncio._get_running_loop()
         disp = cls(loop, host, port, worker_id, request_id,
-                   connect_timeout, max_msg_len)
+                   connect_timeout)
         disp._grpc_thread.start()
         await disp._grpc_connected_fut
         logger.info('Successfully opened gRPC channel to %s:%s', host, port)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixes Issue https://github.com/Azure/azure-functions-python-worker/pull/632/files#diff-9a16b2f8bcbe955d554031aec6e96442R47

The `self._grpc_max_msg_len` is set to `None` due to passing None into `dispatcher.\_\_init\_\_()` method
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

---

### PR information
- [X] The title of the PR is clear and informative.
- [X] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [X] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.
<!-- - [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch. -->

### Quality of Code and Contribution Guidelines
- [X] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).