### PR TITLE
Make our worker code backward compatible with protobuf<3.8.0

### DIFF
--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -170,9 +170,9 @@ class Dispatcher(metaclass=DispatcherMeta):
             log_level = getattr(protos.RpcLog, 'None')
 
         if is_system_log_category(record.name):
-            log_category = protos.RpcLog.RpcLogCategory.System
+            log_category = protos.RpcLog.RpcLogCategory.Value('System')
         else:  # customers using logging will yield 'root' in record.name
-            log_category = protos.RpcLog.RpcLogCategory.User
+            log_category = protos.RpcLog.RpcLogCategory.Value('User')
 
         log = dict(
             level=log_level,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- please list issues, if any -->
Fixes the rest of the dispatcher not found issue.
Azure Functions Python Worker is using a **Protobuf** version of **3.12**
Customer could break our worker code by brining a **Protobuf** package **< 3.8.0**
**Issue Protobuf < 3.8.0**: https://github.com/protocolbuffers/protobuf/issues/6028
**Fix released Protobuf >= 3.8.0**: https://github.com/protocolbuffers/protobuf/commit/0de6577b7d5702a133f0eade4ddf6b94893e975a

We should use the backward compatible syntax in worker RpcLogCategory.
---
<!--
Please add an informative description that covers that changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
