### PR TITLE
Fix PYTHON_THREADPOOL_THREAD_COUNT not apply to Linux Conusmption

### DIFF
--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -493,7 +493,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         """Deallocate the current synchronous thread pool. If the thread pool
         does not exist, this will be a no op.
         """
-        if self._sync_call_tp is not None:
+        if getattr(self, '_sync_call_tp', None):
             self._sync_call_tp.shutdown()
             self._sync_call_tp = None
 

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -316,7 +316,7 @@ class Dispatcher(metaclass=DispatcherMeta):
                 function_id)
 
             function_invocation_logs: List[str] = [
-                f'Received FunctionInvocationRequest',
+                'Received FunctionInvocationRequest',
                 f'request ID: {self.request_id}',
                 f'function ID: {function_id}',
                 f'invocation ID: {invocation_id}',

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -77,11 +77,10 @@ class Dispatcher(metaclass=DispatcherMeta):
 
         # We allow the customer to change synchronous thread pool count by
         # PYTHON_THREADPOOL_THREAD_COUNT app setting. The default value is 1.
-        self._sync_tp_max_workers: int = PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT
-        self._sync_call_tp: Optional[concurrent.futures.Executor] = None
-
-        sync_tp_max_worker: int = self._get_sync_tp_max_workers()
-        self._create_or_update_sync_call_tp(sync_tp_max_worker)
+        self._sync_tp_max_workers: int = self._get_sync_tp_max_workers()
+        self._sync_call_tp: concurrent.futures.Executor = (
+            self._create_sync_call_tp(self._sync_tp_max_workers)
+        )
 
         self._grpc_connect_timeout: float = grpc_connect_timeout
         # This is set to -1 by default to remove the limitation on msg size
@@ -432,8 +431,10 @@ class Dispatcher(metaclass=DispatcherMeta):
                 os.environ[var] = env_vars[var]
 
             # Apply PYTHON_THREADPOOL_THREAD_COUNT
-            sync_tp_max_worker: int = self._get_sync_tp_max_workers()
-            self._create_or_update_sync_call_tp(sync_tp_max_worker)
+            self._sync_tp_max_workers = self._get_sync_tp_max_workers()
+            self._sync_call_tp = (
+                self._create_sync_call_tp(self._sync_tp_max_workers)
+            )
 
             # Reload package namespaces for customer's libraries
             packages_to_reload = ['azure', 'google']
@@ -518,15 +519,12 @@ class Dispatcher(metaclass=DispatcherMeta):
             default_value=f'{PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT}',
             validator=tp_max_workers_validator))
 
-    def _create_or_update_sync_call_tp(self, max_worker: int):
+    def _create_sync_call_tp(
+            self, max_worker: int) -> concurrent.futures.Executor:
         """Update the self._sync_call_tp executor with the proper max_worker.
-        Side effects:
-            - Update self._sync_tp_max_workers to max_worker
-            - Update self._sync_call_tp to have max_worker number of threads
         """
         self._stop_sync_call_tp()
-        self._sync_tp_max_workers = max_worker
-        self._sync_call_tp = concurrent.futures.ThreadPoolExecutor(
+        return concurrent.futures.ThreadPoolExecutor(
             max_workers=max_worker
         )
 

--- a/tests/unittests/dispatcher_functions/show_context_async/__init__.py
+++ b/tests/unittests/dispatcher_functions/show_context_async/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import json
+import azure.functions as func
+
+
+async def main(req: func.HttpRequest,
+               context: func.Context) -> func.HttpResponse:
+    result = {
+        'function_directory': context.function_directory,
+        'function_name': context.function_name
+    }
+    return func.HttpResponse(body=json.dumps(result),
+                             mimetype='application/json')

--- a/tests/unittests/dispatcher_functions/show_context_async/function.json
+++ b/tests/unittests/dispatcher_functions/show_context_async/function.json
@@ -1,0 +1,15 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -26,6 +26,10 @@ class TestDispatcher(testutils.AsyncTestCase):
         async with ctrl as host:
             await self._check_if_function_is_ok(host)
             self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+            self.assertIsNotNone(ctrl._worker._sync_call_tp)
+
+            # Check if the dispatcher still function
+            await self._check_if_function_is_ok(host)
 
     async def test_dispatcher_sync_threadpool_set_worker(self):
         """Test if the sync threadpool maximum worker can be set
@@ -37,61 +41,192 @@ class TestDispatcher(testutils.AsyncTestCase):
         async with ctrl as host:
             await self._check_if_function_is_ok(host)
             self.assertEqual(ctrl._worker._sync_tp_max_workers, 5)
+            self.assertIsNotNone(ctrl._worker._sync_call_tp)
 
-    @patch('azure_functions_worker.dispatcher.logger')
-    async def test_dispatcher_sync_threadpool_invalid_worker_count(self,
-                                                                   mock_logger):
+            # Check if the dispatcher still function
+            await self._check_if_function_is_ok(host)
+
+    async def test_dispatcher_sync_threadpool_invalid_worker_count(self):
         """Test when sync threadpool maximum worker is set to an invalid value,
         the host should fallback to default value 1
         """
-        # Configure thread pool max worker to an invalid value
-        os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: 'invalid'})
+        # The @patch decorator does not work as expected and will suppress
+        # any assertion failures in the async test cases.
+        # Thus we're moving the patch() method to use the with syntax
+
+        with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
+            # Configure thread pool max worker to an invalid value
+            os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: 'invalid'})
+            ctrl = testutils.start_mockhost(
+                script_root=self.dispatcher_funcs_dir)
+
+            async with ctrl as host:
+                await self._check_if_function_is_ok(host)
+
+                # Ensure the dispatcher sync threadpool should fallback to 1
+                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+                self.assertIsNotNone(ctrl._worker._sync_call_tp)
+
+                # Check if the dispatcher still function
+                await self._check_if_function_is_ok(host)
+
+            mock_logger.warning.assert_any_call(
+                f'{PYTHON_THREADPOOL_THREAD_COUNT} must be an integer')
+
+    async def test_dispatcher_sync_threadpool_below_min_setting(self):
+        """Test if the sync threadpool will pick up default value when the
+        setting is below minimum
+        """
+
+        with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
+            # Configure thread pool max worker to an invalid value
+            os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '0'})
+            ctrl = testutils.start_mockhost(
+                script_root=self.dispatcher_funcs_dir)
+
+            async with ctrl as host:
+                await self._check_if_function_is_ok(host)
+
+                # Ensure the dispatcher sync threadpool should fallback to 1
+                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+                self.assertIsNotNone(ctrl._worker._sync_call_tp)
+
+                # Check if the dispatcher still function
+                await self._check_if_function_is_ok(host)
+
+            mock_logger.warning.assert_any_call(
+                f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
+                'between 1 and 32')
+
+    async def test_dispatcher_sync_threadpool_exceed_max_setting(self):
+        """Test if the sync threadpool will pick up default value when the
+        setting is above maximum
+        """
+
+        with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
+            # Configure thread pool max worker to an invalid value
+            os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '33'})
+            ctrl = testutils.start_mockhost(
+                script_root=self.dispatcher_funcs_dir)
+
+            async with ctrl as host:
+                await self._check_if_function_is_ok(host)
+
+                # Ensure the dispatcher sync threadpool should fallback to 1
+                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+                self.assertIsNotNone(ctrl._worker._sync_call_tp)
+
+                # Check if the dispatcher still function
+                await self._check_if_function_is_ok(host)
+
+            mock_logger.warning.assert_any_call(
+                f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
+                'between 1 and 32')
+
+    async def test_dispatcher_sync_threadpool_in_placeholder(self):
+        """Test if the sync threadpool will pick up app setting in placeholder
+        mode (Linux Consumption)
+        """
+
         ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
 
         async with ctrl as host:
             await self._check_if_function_is_ok(host)
 
-            # Ensure the dispatcher sync threadpool should fallback to 1
-            self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+            # Reload environment variable on specialization
+            await host.reload_environment(environment={
+                PYTHON_THREADPOOL_THREAD_COUNT: '3'
+            })
 
-        mock_logger.warning.assert_any_call(
-            f'{PYTHON_THREADPOOL_THREAD_COUNT} must be an integer')
+            # Ensure the dispatcher sync threadpool should update to 3
+            self.assertEqual(ctrl._worker._sync_tp_max_workers, 3)
+            self.assertIsNotNone(ctrl._worker._sync_call_tp)
 
-    @patch('azure_functions_worker.dispatcher.logger')
-    async def test_dispatcher_sync_threadpool_below_min_setting(self,
-                                                                mock_logger):
-        # Configure thread pool max worker to an invalid value
-        os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '0'})
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
-        async with ctrl as host:
+            # Check if the dispatcher still function
             await self._check_if_function_is_ok(host)
 
-            # Ensure the dispatcher sync threadpool should fallback to 1
-            self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+    async def test_dispatcher_sync_threadpool_in_placeholder_invalid(self):
+        """Test if the sync threadpool will use the default setting when the
+        app setting is invalid
+        """
 
-        mock_logger.warning.assert_any_call(
-            f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value between '
-            '1 and 32')
-
-    @patch('azure_functions_worker.dispatcher.logger')
-    async def test_dispatcher_sync_threadpool_exceed_max_setting(
-        self,
-        mock_logger
-    ):
-        # Configure thread pool max worker to an invalid value
-        os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '33'})
         ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
 
-        async with ctrl as host:
-            await self._check_if_function_is_ok(host)
+        with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
+            async with ctrl as host:
+                await self._check_if_function_is_ok(host)
 
-            # Ensure the dispatcher sync threadpool should fallback to 1
-            self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+                # Reload environment variable on specialization
+                await host.reload_environment(environment={
+                    PYTHON_THREADPOOL_THREAD_COUNT: 'invalid'
+                })
 
-        mock_logger.warning.assert_any_call(
-            f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value between '
-            '1 and 32')
+                # Ensure the dispatcher sync threadpool should fallback to 1
+                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+                self.assertIsNotNone(ctrl._worker._sync_call_tp)
+
+                # Check if the dispatcher still function
+                await self._check_if_function_is_ok(host)
+
+                # Check warning message
+                mock_logger.warning.assert_any_call(
+                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be an integer')
+
+    async def test_dispatcher_sync_threadpool_in_placeholder_above_max(self):
+        """Test if the sync threadpool will use the default setting when the
+        app setting is above maximum
+        """
+
+        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
+
+        with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
+            async with ctrl as host:
+                await self._check_if_function_is_ok(host)
+
+                # Reload environment variable on specialization
+                await host.reload_environment(environment={
+                    PYTHON_THREADPOOL_THREAD_COUNT: '33'
+                })
+
+                # Ensure the dispatcher sync threadpool should fallback to 1
+                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+                self.assertIsNotNone(ctrl._worker._sync_call_tp)
+
+                # Check if the dispatcher still function
+                await self._check_if_function_is_ok(host)
+
+                # Check warning message
+                mock_logger.warning.assert_any_call(
+                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
+                    'between 1 and 32')
+
+    async def test_dispatcher_sync_threadpool_in_placeholder_below_min(self):
+        """Test if the sync threadpool will use the default setting when the
+        app setting is below minimum
+        """
+
+        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
+
+        with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
+            async with ctrl as host:
+                await self._check_if_function_is_ok(host)
+
+                # Reload environment variable on specialization
+                await host.reload_environment(environment={
+                    PYTHON_THREADPOOL_THREAD_COUNT: '0'
+                })
+
+                # Ensure the dispatcher sync threadpool should fallback to 1
+                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
+                self.assertIsNotNone(ctrl._worker._sync_call_tp)
+
+                # Check if the dispatcher still function
+                await self._check_if_function_is_ok(host)
+
+                # Check warning message
+                mock_logger.warning.assert_any_call(
+                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
+                    'between 1 and 32')
 
     async def _check_if_function_is_ok(self, host):
         # Ensure the function can be properly loaded


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- please list issues, if any -->
This is a fix to an issue where in Linux Consumption, the **PYTHON_THREADPOOL_THREAD_COUNT** app setting is not properly applied to an instance during specialization. This will make the Python worker in Linux Consumption ignore the app setting, making the maximum worker count always to 1. 

Miscellaneous:
1. I move `@patch` decorator in unittests to use **with patch()** syntax, since previously, it suppresses all assertion exceptions in **async** test cases.
2. Add a **reload_environment()** function in testutil to help us mock Linux Consumption specialization

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
