### PR TITLE
Disable Python 3.9 build in Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,9 +57,6 @@ jobs:
       Python38V3:
         pythonVersion: '3.8'
         workerPath: 'python/prodV3/worker.py'
-      Python39V3:
-        pythonVersion: '3.9'
-        workerPath: 'python/prodV3/worker.py'
   steps:
   - template: pack/templates/win_env_gen.yml
     parameters:
@@ -81,9 +78,6 @@ jobs:
         workerPath: 'python/prodV3/worker.py'
       Python38V3:
         pythonVersion: '3.8'
-        workerPath: 'python/prodV3/worker.py'
-      Python39V3:
-        pythonVersion: '3.9'
         workerPath: 'python/prodV3/worker.py'
   steps:
   - template: pack/templates/win_env_gen.yml

--- a/pack/Microsoft.Azure.Functions.V3.PythonWorker.nuspec
+++ b/pack/Microsoft.Azure.Functions.V3.PythonWorker.nuspec
@@ -22,8 +22,8 @@
     <file src="..\3.8_WINDOWS_X86\**" target="tools\3.8\WINDOWS\X86" />
     <file src="..\3.8_LINUX_X64\**" target="tools\3.8\LINUX\X64" />
     <file src="..\3.8_OSX_X64\**" target="tools\3.8\OSX\X64" />
-    <file src="..\3.9_WINDOWS_X64\**" target="tools\3.9\WINDOWS\X64" />
-    <file src="..\3.9_WINDOWS_X86\**" target="tools\3.9\WINDOWS\X86" />
+    <!-- <file src="..\3.9_WINDOWS_X64\**" target="tools\3.9\WINDOWS\X64" /> -->
+    <!-- <file src="..\3.9_WINDOWS_X86\**" target="tools\3.9\WINDOWS\X86" /> -->
     <file src="..\3.9_LINUX_X64\**" target="tools\3.9\LINUX\X64" />
     <file src="..\3.9_OSX_X64\**" target="tools\3.9\OSX\X64" />
     <file src="..\python\prodV3\worker.config.json" target="tools" />


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

### Description


Since GRPC does not have Windows Python 3.9 wheel, we should release the Azure Functions Python 3.9 preview without windows support.

https://github.com/grpc/grpc/issues/24344

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
