### PR TITLE
Upgrade Linux pip before packaging worker

### DIFF
--- a/pack/scripts/nix_deps.sh
+++ b/pack/scripts/nix_deps.sh
@@ -2,6 +2,8 @@
 
 python -m venv .env
 source .env/bin/activate
+python -m pip install --upgrade pip
+
 python -m pip install .
 
 python -m pip install . azure-functions --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- please list issues, if any -->
There's a size increase (~90MB) in grpcio library for Linux Python 3.6 worker which is caused by the manylinux2010 wheel is only recognized with pip >= 19.0.0.

I add the linux pip upgrade command in our linux package script.
Windows package script already has it.

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [x] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
