### PR TITLE
Setting PTPTC to None for Py3.9 only

### DIFF
--- a/azure_functions_worker/testutils.py
+++ b/azure_functions_worker/testutils.py
@@ -29,6 +29,7 @@ import typing
 import unittest
 import uuid
 
+import asynctest as asynctest
 import grpc
 import requests
 
@@ -122,7 +123,7 @@ class AsyncTestCaseMeta(type(unittest.TestCase)):
         return wrapper
 
 
-class AsyncTestCase(unittest.TestCase, metaclass=AsyncTestCaseMeta):
+class AsyncTestCase(asynctest.TestCase, metaclass=AsyncTestCaseMeta):
     pass
 
 

--- a/azure_functions_worker/testutils.py
+++ b/azure_functions_worker/testutils.py
@@ -319,13 +319,12 @@ class _MockWebHost:
         self._connected_fut = loop.create_future()
         self._in_queue = queue.Queue()
         self._out_aqueue = asyncio.Queue(loop=self._loop)
-        self._threadpool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1)
+        self._threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         self._server = grpc.server(self._threadpool)
         self._servicer = _MockWebHostServicer(self)
+
         protos.add_FunctionRpcServicer_to_server(self._servicer, self._server)
         self._port = self._server.add_insecure_port(f'{LOCALHOST}:0')
-
         self._worker_id = self.make_id()
         self._request_id = self.make_id()
 
@@ -487,10 +486,10 @@ class _MockWebHostController:
 
         await self._host.start()
 
-        self._worker = await dispatcher. \
+        self._worker = await dispatcher.\
             Dispatcher.connect(LOCALHOST, self._host._port,
-                               self._host.worker_id,
-                               self._host.request_id, connect_timeout=5.0)
+                               self._host.worker_id, self._host.request_id,
+                               connect_timeout=5.0)
 
         self._worker_task = loop.create_task(self._worker.dispatch_forever())
 

--- a/setup.py
+++ b/setup.py
@@ -272,10 +272,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: MacOS :: MacOS X',
@@ -308,7 +308,8 @@ setup(
             'pytest-xdist',
             'pytest-randomly',
             'pytest-instafail',
-            'pytest-rerunfailures'
+            'pytest-rerunfailures',
+            'asynctest'
         ]
     },
     include_package_data=True,

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -93,9 +93,8 @@ class TestThreadPoolSettingsPython37(testutils.AsyncTestCase):
                 await self._assert_workers_threadpool(self._ctrl, host,
                                                       self._default_workers)
             mock_logger.warning.assert_any_call(
-                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
-                    'between 1 and 32. '
-                    'Reverting to default value for max_workers')
+                f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
+                'between 1 and 32. Reverting to default value for max_workers')
 
     async def test_dispatcher_sync_threadpool_exceed_max_setting(self):
         """Test if the sync threadpool will pick up default value when the
@@ -297,7 +296,8 @@ class TestThreadPoolSettingsPython37(testutils.AsyncTestCase):
                     'function type: async'
                 )
 
-    async def _assert_workers_threadpool(self, ctrl, host, expected_worker_count):
+    async def _assert_workers_threadpool(self, ctrl, host,
+                                         expected_worker_count):
         self.assertIsNotNone(ctrl._worker._sync_call_tp)
         self.assertEqual(ctrl._worker.get_sync_tp_workers_set(),
                          expected_worker_count)
@@ -373,10 +373,12 @@ class TestThreadPoolSettingsPython39(TestThreadPoolSettingsPython37):
     def setUp(self):
         super(TestThreadPoolSettingsPython39, self).setUp()
 
+        self.mock_os_cpu = patch(
+            'azure_functions_worker.dispatcher.os.cpu_count',
+            return_value=2)
+        self.mock_os_cpu.start()
         # 6 - based on 2 cores - min(32, (os.cpu_count() or 1) + 4) - 2 + 4
         self._default_workers: Optional[int] = 6
-        self.mock_os_cpu = patch(
-                'azure_functions_worker.dispatcher.os.cpu_count', 2)
 
         self.mock_version_info = patch(
             'azure_functions_worker.dispatcher.sys.version_info',

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -1,55 +1,70 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-from typing import Tuple
+import collections as col
 import os
+from typing import Optional, Tuple
 from unittest.mock import patch
+
 from azure_functions_worker import protos
 from azure_functions_worker import testutils
-from azure_functions_worker.constants import PYTHON_THREADPOOL_THREAD_COUNT
+from azure_functions_worker.constants import PYTHON_THREADPOOL_THREAD_COUNT, \
+    PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT
+
+SysVersionInfo = col.namedtuple("VersionInfo", ["major", "minor", "micro",
+                                                "releaselevel", "serial"])
+DISPATCHER_FUNCTIONS_DIR = testutils.UNIT_TESTS_FOLDER / 'dispatcher_functions'
 
 
-class TestDispatcher(testutils.AsyncTestCase):
-    dispatcher_funcs_dir = testutils.UNIT_TESTS_FOLDER / 'dispatcher_functions'
+class TestThreadPoolSettingsPython37(testutils.AsyncTestCase):
+    """Base test class for testing thread pool settings for sync threadpool
+    worker count. This class specifically sets sys.version_info to return as
+    Python 3.7 and extended classes change this value and other platform
+    specific values to test the behavior across the different python versions.
 
+    - Why not python 3.6?
+    - In Azure.Functions (library), the typing_inspect module imports specific
+    modules which are not available on systems where Python 3.7+ is installed.
+
+    Ref:
+    NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
+    """
     def setUp(self):
+        self._ctrl = testutils.start_mockhost(
+            script_root=DISPATCHER_FUNCTIONS_DIR)
+        self._default_workers: Optional[
+            int] = PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT
         self._pre_env = dict(os.environ)
+        self.mock_version_info = patch(
+            'azure_functions_worker.dispatcher.sys.version_info',
+            SysVersionInfo(3, 7, 0, 'final', 0))
+        self.mock_version_info.start()
 
     def tearDown(self):
         os.environ.clear()
         os.environ.update(self._pre_env)
+        self.mock_version_info.stop()
 
     async def test_dispatcher_sync_threadpool_default_worker(self):
-        """Test if the sync threadpool has maximum worker count set to 1
-        by default
+        """Test if the sync threadpool has maximum worker count set the
+        correct default value
         """
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
-        async with ctrl as host:
-            await self._check_if_function_is_ok(host)
-            self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
-            self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-            # Check if the dispatcher still function
-            await self._check_if_function_is_ok(host)
+        async with self._ctrl as host:
+            # await self._check_if_function_is_ok(host)
+            await self._assert_workers_threadpool(self._ctrl, host,
+                                                  self._default_workers)
 
     async def test_dispatcher_sync_threadpool_set_worker(self):
         """Test if the sync threadpool maximum worker can be set
         """
         # Configure thread pool max worker
         os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '5'})
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
-        async with ctrl as host:
+        async with self._ctrl as host:
             await self._check_if_function_is_ok(host)
-            self.assertEqual(ctrl._worker._sync_tp_max_workers, 5)
-            self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-            # Check if the dispatcher still function
-            await self._check_if_function_is_ok(host)
+            await self._assert_workers_threadpool(self._ctrl, host, 5)
 
     async def test_dispatcher_sync_threadpool_invalid_worker_count(self):
         """Test when sync threadpool maximum worker is set to an invalid value,
-        the host should fallback to default value 1
+        the host should fallback to default value
         """
         # The @patch decorator does not work as expected and will suppress
         # any assertion failures in the async test cases.
@@ -58,19 +73,11 @@ class TestDispatcher(testutils.AsyncTestCase):
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
             # Configure thread pool max worker to an invalid value
             os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: 'invalid'})
-            ctrl = testutils.start_mockhost(
-                script_root=self.dispatcher_funcs_dir)
 
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await self._check_if_function_is_ok(host)
-
-                # Ensure the dispatcher sync threadpool should fallback to 1
-                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
-                self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-                # Check if the dispatcher still function
-                await self._check_if_function_is_ok(host)
-
+                await self._assert_workers_threadpool(self._ctrl, host,
+                                                      self._default_workers)
             mock_logger.warning.assert_any_call(
                 f'{PYTHON_THREADPOOL_THREAD_COUNT} must be an integer')
 
@@ -78,96 +85,65 @@ class TestDispatcher(testutils.AsyncTestCase):
         """Test if the sync threadpool will pick up default value when the
         setting is below minimum
         """
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
             # Configure thread pool max worker to an invalid value
             os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '0'})
-            ctrl = testutils.start_mockhost(
-                script_root=self.dispatcher_funcs_dir)
-
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await self._check_if_function_is_ok(host)
-
-                # Ensure the dispatcher sync threadpool should fallback to 1
-                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
-                self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-                # Check if the dispatcher still function
-                await self._check_if_function_is_ok(host)
-
+                await self._assert_workers_threadpool(self._ctrl, host,
+                                                      self._default_workers)
             mock_logger.warning.assert_any_call(
-                f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
-                'between 1 and 32')
+                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
+                    'between 1 and 32. '
+                    'Reverting to default value for max_workers')
 
     async def test_dispatcher_sync_threadpool_exceed_max_setting(self):
         """Test if the sync threadpool will pick up default value when the
         setting is above maximum
         """
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
             # Configure thread pool max worker to an invalid value
             os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '33'})
-            ctrl = testutils.start_mockhost(
-                script_root=self.dispatcher_funcs_dir)
-
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await self._check_if_function_is_ok(host)
 
                 # Ensure the dispatcher sync threadpool should fallback to 1
-                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
-                self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-                # Check if the dispatcher still function
-                await self._check_if_function_is_ok(host)
+                await self._assert_workers_threadpool(self._ctrl, host,
+                                                      self._default_workers)
 
             mock_logger.warning.assert_any_call(
                 f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
-                'between 1 and 32')
+                'between 1 and 32. '
+                'Reverting to default value for max_workers')
 
     async def test_dispatcher_sync_threadpool_in_placeholder(self):
         """Test if the sync threadpool will pick up app setting in placeholder
         mode (Linux Consumption)
         """
-
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
-        async with ctrl as host:
+        async with self._ctrl as host:
             await self._check_if_function_is_ok(host)
 
             # Reload environment variable on specialization
             await host.reload_environment(environment={
                 PYTHON_THREADPOOL_THREAD_COUNT: '3'
             })
-
-            # Ensure the dispatcher sync threadpool should update to 3
-            self.assertEqual(ctrl._worker._sync_tp_max_workers, 3)
-            self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-            # Check if the dispatcher still function
-            await self._check_if_function_is_ok(host)
+            # Ensure the dispatcher sync threadpool should fallback to 1
+            await self._assert_workers_threadpool(self._ctrl, host, 3)
 
     async def test_dispatcher_sync_threadpool_in_placeholder_invalid(self):
         """Test if the sync threadpool will use the default setting when the
         app setting is invalid
         """
-
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await self._check_if_function_is_ok(host)
 
                 # Reload environment variable on specialization
                 await host.reload_environment(environment={
                     PYTHON_THREADPOOL_THREAD_COUNT: 'invalid'
                 })
-
-                # Ensure the dispatcher sync threadpool should fallback to 1
-                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
-                self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-                # Check if the dispatcher still function
-                await self._check_if_function_is_ok(host)
+                await self._assert_workers_threadpool(self._ctrl, host,
+                                                      self._default_workers)
 
                 # Check warning message
                 mock_logger.warning.assert_any_call(
@@ -177,39 +153,29 @@ class TestDispatcher(testutils.AsyncTestCase):
         """Test if the sync threadpool will use the default setting when the
         app setting is above maximum
         """
-
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await self._check_if_function_is_ok(host)
 
                 # Reload environment variable on specialization
                 await host.reload_environment(environment={
                     PYTHON_THREADPOOL_THREAD_COUNT: '33'
                 })
+                await self._assert_workers_threadpool(self._ctrl, host,
+                                                      self._default_workers)
 
-                # Ensure the dispatcher sync threadpool should fallback to 1
-                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
-                self.assertIsNotNone(ctrl._worker._sync_call_tp)
-
-                # Check if the dispatcher still function
-                await self._check_if_function_is_ok(host)
-
-                # Check warning message
                 mock_logger.warning.assert_any_call(
-                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
-                    'between 1 and 32')
+                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a '
+                    f'value '
+                    'between 1 and 32. '
+                    'Reverting to default value for max_workers')
 
     async def test_dispatcher_sync_threadpool_in_placeholder_below_min(self):
         """Test if the sync threadpool will use the default setting when the
         app setting is below minimum
         """
-
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await self._check_if_function_is_ok(host)
 
                 # Reload environment variable on specialization
@@ -217,24 +183,19 @@ class TestDispatcher(testutils.AsyncTestCase):
                     PYTHON_THREADPOOL_THREAD_COUNT: '0'
                 })
 
-                # Ensure the dispatcher sync threadpool should fallback to 1
-                self.assertEqual(ctrl._worker._sync_tp_max_workers, 1)
-                self.assertIsNotNone(ctrl._worker._sync_call_tp)
+                await self._assert_workers_threadpool(self._ctrl, host,
+                                                      self._default_workers)
 
-                # Check if the dispatcher still function
-                await self._check_if_function_is_ok(host)
-
-                # Check warning message
                 mock_logger.warning.assert_any_call(
-                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a value '
-                    'between 1 and 32')
+                    f'{PYTHON_THREADPOOL_THREAD_COUNT} must be set to a '
+                    f'value '
+                    'between 1 and 32. '
+                    'Reverting to default value for max_workers')
 
     async def test_sync_invocation_request_log(self):
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
-                request_id: str = ctrl._worker._request_id
+            async with self._ctrl as host:
+                request_id: str = self._ctrl._worker._request_id
                 func_id, invoke_id = await self._check_if_function_is_ok(host)
 
                 mock_logger.info.assert_any_call(
@@ -243,15 +204,13 @@ class TestDispatcher(testutils.AsyncTestCase):
                     f'function ID: {func_id}, '
                     f'invocation ID: {invoke_id}, '
                     'function type: sync, '
-                    'sync threadpool max workers: 1'
+                    f'sync threadpool max workers: {self._default_workers}'
                 )
 
     async def test_async_invocation_request_log(self):
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
-                request_id: str = ctrl._worker._request_id
+            async with self._ctrl as host:
+                request_id: str = self._ctrl._worker._request_id
                 func_id, invoke_id = (
                     await self._check_if_async_function_is_ok(host)
                 )
@@ -265,12 +224,11 @@ class TestDispatcher(testutils.AsyncTestCase):
                 )
 
     async def test_sync_invocation_request_log_threads(self):
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
         os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '5'})
 
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
-                request_id: str = ctrl._worker._request_id
+            async with self._ctrl as host:
+                request_id: str = self._ctrl._worker._request_id
                 func_id, invoke_id = await self._check_if_function_is_ok(host)
 
                 mock_logger.info.assert_any_call(
@@ -283,12 +241,11 @@ class TestDispatcher(testutils.AsyncTestCase):
                 )
 
     async def test_async_invocation_request_log_threads(self):
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
         os.environ.update({PYTHON_THREADPOOL_THREAD_COUNT: '4'})
 
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
-                request_id: str = ctrl._worker._request_id
+            async with self._ctrl as host:
+                request_id: str = self._ctrl._worker._request_id
                 func_id, invoke_id = (
                     await self._check_if_async_function_is_ok(host)
                 )
@@ -302,15 +259,13 @@ class TestDispatcher(testutils.AsyncTestCase):
                 )
 
     async def test_sync_invocation_request_log_in_placeholder_threads(self):
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await host.reload_environment(environment={
                     PYTHON_THREADPOOL_THREAD_COUNT: '5'
                 })
 
-                request_id: str = ctrl._worker._request_id
+                request_id: str = self._ctrl._worker._request_id
                 func_id, invoke_id = await self._check_if_function_is_ok(host)
 
                 mock_logger.info.assert_any_call(
@@ -323,15 +278,13 @@ class TestDispatcher(testutils.AsyncTestCase):
                 )
 
     async def test_async_invocation_request_log_in_placeholder_threads(self):
-        ctrl = testutils.start_mockhost(script_root=self.dispatcher_funcs_dir)
-
         with patch('azure_functions_worker.dispatcher.logger') as mock_logger:
-            async with ctrl as host:
+            async with self._ctrl as host:
                 await host.reload_environment(environment={
                     PYTHON_THREADPOOL_THREAD_COUNT: '5'
                 })
 
-                request_id: str = ctrl._worker._request_id
+                request_id: str = self._ctrl._worker._request_id
                 func_id, invoke_id = (
                     await self._check_if_async_function_is_ok(host)
                 )
@@ -344,9 +297,19 @@ class TestDispatcher(testutils.AsyncTestCase):
                     'function type: async'
                 )
 
+    async def _assert_workers_threadpool(self, ctrl, host, expected_worker_count):
+        self.assertIsNotNone(ctrl._worker._sync_call_tp)
+        self.assertEqual(ctrl._worker.get_sync_tp_workers_set(),
+                         expected_worker_count)
+        # Check if the dispatcher still function
+        await self._check_if_function_is_ok(host)
+
     async def _check_if_function_is_ok(self, host) -> Tuple[str, str]:
         # Ensure the function can be properly loaded
         func_id, load_r = await host.load_function('show_context')
+        print("%%%%%%%%%%%")
+        print(load_r)
+        print("%%%%%%%%%%%")
         self.assertEqual(load_r.response.function_id, func_id)
         self.assertEqual(load_r.response.result.status,
                          protos.StatusResult.Success)
@@ -367,7 +330,7 @@ class TestDispatcher(testutils.AsyncTestCase):
         self.assertEqual(call_r.response.result.status,
                          protos.StatusResult.Success)
 
-        return (func_id, invoke_id)
+        return func_id, invoke_id
 
     async def _check_if_async_function_is_ok(self, host) -> Tuple[str, str]:
         # Ensure the function can be properly loaded
@@ -392,4 +355,32 @@ class TestDispatcher(testutils.AsyncTestCase):
         self.assertEqual(call_r.response.result.status,
                          protos.StatusResult.Success)
 
-        return (func_id, invoke_id)
+        return func_id, invoke_id
+
+
+class TestThreadPoolSettingsPython38(TestThreadPoolSettingsPython37):
+    def setUp(self):
+        super(TestThreadPoolSettingsPython38, self).setUp()
+        self.mock_version_info = patch(
+            'azure_functions_worker.dispatcher.sys.version_info',
+            SysVersionInfo(3, 8, 0, 'final', 0))
+        self.mock_version_info.start()
+
+    def tearDown(self):
+        self.mock_version_info.stop()
+        super(TestThreadPoolSettingsPython38, self).tearDown()
+
+
+class TestThreadPoolSettingsPython39(TestThreadPoolSettingsPython37):
+    def setUp(self):
+        super(TestThreadPoolSettingsPython39, self).setUp()
+        self._default_workers: Optional[
+            int] = min(32, (os.cpu_count() or 1) + 4)
+        self.mock_version_info = patch(
+            'azure_functions_worker.dispatcher.sys.version_info',
+            SysVersionInfo(3, 9, 0, 'final', 0))
+        self.mock_version_info.start()
+
+    def tearDown(self):
+        self.mock_version_info.stop()
+        super(TestThreadPoolSettingsPython39, self).tearDown()

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -307,9 +307,6 @@ class TestThreadPoolSettingsPython37(testutils.AsyncTestCase):
     async def _check_if_function_is_ok(self, host) -> Tuple[str, str]:
         # Ensure the function can be properly loaded
         func_id, load_r = await host.load_function('show_context')
-        print("%%%%%%%%%%%")
-        print(load_r)
-        print("%%%%%%%%%%%")
         self.assertEqual(load_r.response.function_id, func_id)
         self.assertEqual(load_r.response.result.status,
                          protos.StatusResult.Success)
@@ -367,20 +364,27 @@ class TestThreadPoolSettingsPython38(TestThreadPoolSettingsPython37):
         self.mock_version_info.start()
 
     def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._pre_env)
         self.mock_version_info.stop()
-        super(TestThreadPoolSettingsPython38, self).tearDown()
 
 
 class TestThreadPoolSettingsPython39(TestThreadPoolSettingsPython37):
     def setUp(self):
         super(TestThreadPoolSettingsPython39, self).setUp()
-        self._default_workers: Optional[
-            int] = min(32, (os.cpu_count() or 1) + 4)
+
+        # 6 - based on 2 cores - min(32, (os.cpu_count() or 1) + 4) - 2 + 4
+        self._default_workers: Optional[int] = 6
+        self.mock_os_cpu = patch(
+                'azure_functions_worker.dispatcher.os.cpu_count', 2)
+
         self.mock_version_info = patch(
             'azure_functions_worker.dispatcher.sys.version_info',
             SysVersionInfo(3, 9, 0, 'final', 0))
         self.mock_version_info.start()
 
     def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._pre_env)
+        self.mock_os_cpu.stop()
         self.mock_version_info.stop()
-        super(TestThreadPoolSettingsPython39, self).tearDown()

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 import collections as col
 import os
+import sys
+import unittest
 from typing import Optional, Tuple
 from unittest.mock import patch
 
@@ -369,13 +371,17 @@ class TestThreadPoolSettingsPython38(TestThreadPoolSettingsPython37):
         self.mock_version_info.stop()
 
 
+@unittest.skipIf(sys.version_info.minor != 9,
+                 "Run the tests only for Python 3.9. In other platforms, "
+                 "as the default passed is None, the cpu_count determines the "
+                 "number of max_workers and we cannot mock the os.cpu_count() "
+                 "in the concurrent.futures.ThreadPoolExecutor")
 class TestThreadPoolSettingsPython39(TestThreadPoolSettingsPython37):
     def setUp(self):
         super(TestThreadPoolSettingsPython39, self).setUp()
 
         self.mock_os_cpu = patch(
-            'azure_functions_worker.dispatcher.os.cpu_count',
-            return_value=2)
+            'os.cpu_count', return_value=2)
         self.mock_os_cpu.start()
         # 6 - based on 2 cores - min(32, (os.cpu_count() or 1) + 4) - 2 + 4
         self._default_workers: Optional[int] = 6


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
- Made the changes for Python 3.9 only.
- Added tests for verifying that the default is None only for Py3.9 and not for others.

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
