### PR TITLE
Re-enable WorkerStatus report in Worker

### DIFF
--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -266,6 +266,7 @@ class Dispatcher(metaclass=DispatcherMeta):
             constants.RAW_HTTP_BODY_BYTES: _TRUE,
             constants.TYPED_DATA_COLLECTION: _TRUE,
             constants.RPC_HTTP_BODY_ONLY: _TRUE,
+            constants.WORKER_STATUS: _TRUE,
             constants.RPC_HTTP_TRIGGER_METADATA_REMOVED: _TRUE,
             constants.SHARED_MEMORY_DATA_TRANSFER: _TRUE,
         }
@@ -285,7 +286,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         # for host to judge scale decisions of out-of-proc languages.
         # Having log here will reduce the responsiveness of the worker.
         return protos.StreamingMessage(
-            request_id=self.request_id,
+            request_id=req.request_id,
             worker_status_response=protos.WorkerStatusResponse())
 
     async def _handle__function_load_request(self, req):

--- a/tests/endtoend/http_functions/default_template/__init__.py
+++ b/tests/endtoend/http_functions/default_template/__init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# flake8: noqa
+import logging
+
+import azure.functions as func
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info('Python HTTP trigger function processed a request.')
+
+    name = req.params.get('name')
+    if not name:
+        try:
+            req_body = req.get_json()
+        except ValueError:
+            pass
+        else:
+            name = req_body.get('name')
+
+    if name:
+        return func.HttpResponse(f"Hello, {name}. This HTTP triggered function executed successfully.")
+    else:
+        return func.HttpResponse(
+             "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response.",
+             status_code=200
+        )

--- a/tests/endtoend/http_functions/default_template/function.json
+++ b/tests/endtoend/http_functions/default_template/function.json
@@ -1,0 +1,20 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/endtoend/test_http_functions.py
+++ b/tests/endtoend/test_http_functions.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+import os
+from unittest.mock import patch
+
 import requests
 from azure_functions_worker import testutils
 
@@ -17,6 +20,12 @@ class TestHttpFunctions(testutils.WebHostTestCase):
     Compared to the unittests/test_http_functions.py, this file is more focus
     on testing the E2E flow scenarios.
     """
+    def setUp(self):
+        self._patch_environ = patch.dict('os.environ', os.environ.copy())
+        self._patch_environ.start()
+
+    def tearDown(self):
+        self._patch_environ.stop()
 
     @classmethod
     def get_script_dir(cls):
@@ -87,6 +96,7 @@ class TestHttpFunctions(testutils.WebHostTestCase):
         _handle__worker_status_request and sends a worker status response back
         to host
         """
+        os.environ['WEBSITE_PING_METRICS_SCALE_ENABLED'] = '0'
         root_url = self.webhost._addr
         health_check_url = f'{root_url}/admin/host/ping'
         r = requests.post(health_check_url,

--- a/tests/endtoend/test_http_functions.py
+++ b/tests/endtoend/test_http_functions.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import requests
+from azure_functions_worker import testutils
+
+REQUEST_TIMEOUT_SEC = 5
+
+
+class TestHttpFunctions(testutils.WebHostTestCase):
+    """Test the native Http Trigger in the local webhost.
+
+    This test class will spawn a webhost from your <project_root>/build/webhost
+    folder and replace the built-in Python with azure_functions_worker from
+    your code base. Since the Http Trigger is a native suport from host, we
+    don't need to setup any external resources.
+
+    Compared to the unittests/test_http_functions.py, this file is more focus
+    on testing the E2E flow scenarios.
+    """
+
+    @classmethod
+    def get_script_dir(cls):
+        return testutils.E2E_TESTS_FOLDER / 'http_functions'
+
+    @testutils.retryable_test(3, 5)
+    def test_function_index_page_should_return_ok(self):
+        """The index page of Azure Functions should return OK in any
+        circumstances
+        """
+        root_url = self.webhost._addr
+        r = requests.get(root_url, timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)
+
+    @testutils.retryable_test(3, 5)
+    def test_default_http_template_should_return_ok(self):
+        """Test if the default template of Http trigger in Python Function app
+        will return OK
+        """
+        r = self.webhost.request('GET', 'default_template',
+                                 timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)
+
+    @testutils.retryable_test(3, 5)
+    def test_default_http_template_should_accept_query_param(self):
+        """Test if the azure.functions SDK is able to deserialize query
+        parameter from the default template
+        """
+        r = self.webhost.request('GET', 'default_template',
+                                 params={'name': 'query'},
+                                 timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)
+        self.assertEqual(
+            r.content,
+            b'Hello, query. This HTTP triggered function executed successfully.'
+        )
+
+    @testutils.retryable_test(3, 5)
+    def test_default_http_template_should_accept_body(self):
+        """Test if the azure.functions SDK is able to deserialize http body
+        and pass it to default template
+        """
+        r = self.webhost.request('POST', 'default_template',
+                                 data='{ "name": "body" }'.encode('utf-8'),
+                                 timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)
+        self.assertEqual(
+            r.content,
+            b'Hello, body. This HTTP triggered function executed successfully.'
+        )
+
+    @testutils.retryable_test(3, 5)
+    def test_worker_status_endpoint_should_return_ok(self):
+        """Test if the worker status endpoint will trigger
+        _handle__worker_status_request and sends a worker status response back
+        to host
+        """
+        root_url = self.webhost._addr
+        health_check_url = f'{root_url}/admin/host/ping'
+        r = requests.post(health_check_url,
+                          params={'checkHealth': '1'},
+                          timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)
+
+    @testutils.retryable_test(3, 5)
+    def test_worker_status_endpoint_should_return_ok_when_disabled(self):
+        """Test if the worker status endpoint will trigger
+        _handle__worker_status_request and sends a worker status response back
+        to host
+        """
+        root_url = self.webhost._addr
+        health_check_url = f'{root_url}/admin/host/ping'
+        r = requests.post(health_check_url,
+                          params={'checkHealth': '1'},
+                          timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

### Description

<!-- please list issues, if any -->
Previously, due to an issue where the latest request id is not sent back to the host, the /admin/host/ping endpoint will always timeout with 408 response. This results in over-scaling behavior in Python function apps. We disabled the WorkerStatus to fix the regression.

In this PR, we're going to re-enable the worker status and fix the request_id that it now should propagate correctly. Adding more unittests and endtoend tests to prevent the issue from happening again.

### Changes

1. Adding a new file to run endtoend tests for Http functions. This file is using the same testing infrastructure as unittest/test_http_functions.py but the scenarios are more focus on overall goodness of endtoend flow.
2. Re-enable the WorkerStatus request handler. Also add a test case in endtoend Http functions to ping the admin/host/ping?checkhealth=1 to ensure the WorkerStatus is responded back to the host.

### Todo

1. Ensure the req.request_id is passed into the handlers correctly 
2. Review unittest cases

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [x] The title of the PR is clear and informative.
- [x] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [x] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
