### PR TITLE
Fix host_out readlines in test_utils

### DIFF
--- a/azure_functions_worker/testutils.py
+++ b/azure_functions_worker/testutils.py
@@ -899,7 +899,11 @@ def start_webhost(*, script_dir=None, stdout=None):
 
     addr = f'http://{LOCALHOST}:{port}'
     health_check_endpoint = f'{addr}/api/ping'
-    host_out = stdout.readlines(100)
+    host_out = ""
+    if stdout is not None and hasattr(stdout,
+                                      "readable") and stdout.readable():
+        host_out = stdout.readlines(100)
+
     for _ in range(5):
         try:
             r = requests.get(health_check_endpoint,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- please list issues, if any -->
Fixes #
Add a check to read line from host_out only if stdout is readable in integration test.

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
