### PR TITLE
Mark python-dateutil as install required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,13 +105,13 @@ INSTALL_REQUIRES = [
     "grpcio~=1.43.0",
     "grpcio-tools~=1.43.0",
     "protobuf~=3.19.3",
-    "azure-functions==1.11.0"
+    "azure-functions==1.11.0",
+    "python-dateutil~=2.8.2",
 ]
 
 EXTRA_REQUIRES = {
     "dev": [
         "azure-eventhub~=5.7.0",  # Used for EventHub E2E tests
-        "python-dateutil~=2.8.2",
         "flask",
         "fastapi",
         "pydantic",


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Linux consumption tests are failing as module 'python-dateutil' not found error happening in https://github.com/Azure/azure-functions-python-worker/pull/1004. The cause is current mesh image is installing worker deps from released worker version instead of setup.py from local or pr branch. We will also update linux consumption test to use v4 images so this change will be taken into runtime image.

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
