### PR TITLE
Fixing format_traceback's change of signature

### DIFF
--- a/azure_functions_worker/logging.py
+++ b/azure_functions_worker/logging.py
@@ -23,8 +23,15 @@ error_handler: Optional[logging.Handler] = None
 
 def format_exception(exception):
     msg = str(exception) + "\n"
-    msg += ''.join(traceback.format_exception(
-        etype=type(exception), value=exception, tb=exception.__traceback__))
+    if sys.version_info.minor < 10:
+        msg += ''.join(traceback.format_exception(
+            etype=type(exception),
+            tb=exception.__traceback__,
+            value=exception))
+    elif sys.version_info.minor == 10:
+        msg += ''.join(traceback.format_exception(exception))
+    else:
+        return exception
     return msg
 
 

--- a/azure_functions_worker/logging.py
+++ b/azure_functions_worker/logging.py
@@ -21,7 +21,7 @@ handler: Optional[logging.Handler] = None
 error_handler: Optional[logging.Handler] = None
 
 
-def format_exception(exception):
+def format_exception(exception: Exception) -> str:
     msg = str(exception) + "\n"
     if sys.version_info.minor < 10:
         msg += ''.join(traceback.format_exception(
@@ -31,7 +31,7 @@ def format_exception(exception):
     elif sys.version_info.minor == 10:
         msg += ''.join(traceback.format_exception(exception))
     else:
-        return exception
+        msg = str(exception)
     return msg
 
 

--- a/azure_functions_worker/utils/common.py
+++ b/azure_functions_worker/utils/common.py
@@ -11,14 +11,14 @@ def is_true_like(setting: str) -> bool:
     if setting is None:
         return False
 
-    return setting.lower().strip() in ['1', 'true', 't', 'yes', 'y']
+    return setting.lower().strip() in {'1', 'true', 't', 'yes', 'y'}
 
 
 def is_false_like(setting: str) -> bool:
     if setting is None:
         return False
 
-    return setting.lower().strip() in ['0', 'false', 'f', 'no', 'n']
+    return setting.lower().strip() in {'0', 'false', 'f', 'no', 'n'}
 
 
 def is_envvar_true(env_key: str) -> bool:

--- a/tests/unittests/test_logging.py
+++ b/tests/unittests/test_logging.py
@@ -3,6 +3,7 @@
 import unittest
 
 from azure_functions_worker import logging as flog
+from azure_functions_worker.logging import format_exception
 
 
 class TestLogging(unittest.TestCase):
@@ -33,3 +34,27 @@ class TestLogging(unittest.TestCase):
         self.assertFalse(flog.is_system_log_category('protobuf'))
         self.assertFalse(flog.is_system_log_category('root'))
         self.assertFalse(flog.is_system_log_category(''))
+
+    def test_format_exception(self):
+        def call0(fn):
+            call1(fn)
+
+        def call1(fn):
+            call2(fn)
+
+        def call2(fn):
+            fn()
+
+        def raising_function():
+            raise ValueError("Value error being raised.", )
+
+        try:
+            call0(raising_function)
+        except ValueError as e:
+            processed_exception = format_exception(e)
+            self.assertIn("call0", processed_exception)
+            self.assertIn("call1", processed_exception)
+            self.assertIn("call2", processed_exception)
+            self.assertIn("f", processed_exception)
+            self.assertIn("tests/unittests/test_logging.py",
+                          processed_exception)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

The signature for format_traceback for Python 3.10 has changed and is a breaking change. This PR addresses that breakage and also adds a test to validate it.

For Python 3.`0 - https://docs.python.org/3/library/traceback.html#traceback.print_exception

> Changed in version 3.10: The `etype` parameter has been renamed to `exc` and is now positional-only.

<img width="810" alt="image" src="https://user-images.githubusercontent.com/1047040/196332557-ad6767ea-9969-4008-88d5-6202caab29ad.png">

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description covering the pull request's changes. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
