### PR TITLE
Reload modules when not in placeholder mode

### DIFF
--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -286,10 +286,16 @@ class Dispatcher(metaclass=DispatcherMeta):
             constants.SHARED_MEMORY_DATA_TRANSFER: _TRUE,
         }
 
-        # Can detech worker packages only when customer's code is present
-        # This only works in dedicated and premium sku.
-        # The consumption sku will switch on environment_reload request.
-        if not DependencyManager.is_in_linux_consumption():
+        # Can detect worker packages only when customer's code is present
+        # This only works in dedicated and premium sku or if not in placeholder
+        # mode in case of linux consumption,=.
+        # The consumption sku will switch on environment_reload request while
+        # getting specialized from placeholder mode.
+        if not (DependencyManager.is_in_linux_consumption()
+                and is_envvar_true("WEBSITE_PLACEHOLDER_MODE")):
+            if not is_envvar_true("WEBSITE_PLACEHOLDER_MODE"):
+                logger.info(f"Not a placeholder. Loading customers"
+                            " dependencies")
             DependencyManager.prioritize_customer_dependencies()
 
         if DependencyManager.is_in_linux_consumption():

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -286,15 +286,7 @@ class Dispatcher(metaclass=DispatcherMeta):
             constants.SHARED_MEMORY_DATA_TRANSFER: _TRUE,
         }
 
-        # Can detect worker packages only when customer's code is present
-        # This only works in dedicated and premium sku or if not in placeholder
-        # mode in case of linux consumption,=.
-        # The consumption sku will switch on environment_reload request while
-        # getting specialized from placeholder mode.
-        if not (DependencyManager.is_in_linux_consumption()
-                and is_envvar_true("WEBSITE_PLACEHOLDER_MODE")):
-            if DependencyManager.is_in_linux_consumption():
-                logger.info("Not a placeholder. Loading customer dependencies")
+        if DependencyManager.should_load_cx_dependencies():
             DependencyManager.prioritize_customer_dependencies()
 
         if DependencyManager.is_in_linux_consumption():
@@ -549,6 +541,8 @@ class Dispatcher(metaclass=DispatcherMeta):
 
     async def _handle__function_environment_reload_request(self, request):
         """Only runs on Linux Consumption placeholder specialization.
+        This is called only when placeholder mode is true. On worker restarts
+        worker init request will be called directly.
         """
         try:
             logger.info('Received FunctionEnvironmentReloadRequest, '

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -293,7 +293,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         # getting specialized from placeholder mode.
         if not (DependencyManager.is_in_linux_consumption()
                 and is_envvar_true("WEBSITE_PLACEHOLDER_MODE")):
-            if not is_envvar_true("WEBSITE_PLACEHOLDER_MODE"):
+            if DependencyManager.is_in_linux_consumption():
                 logger.info("Not a placeholder. Loading customer dependencies")
             DependencyManager.prioritize_customer_dependencies()
 

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -294,8 +294,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         if not (DependencyManager.is_in_linux_consumption()
                 and is_envvar_true("WEBSITE_PLACEHOLDER_MODE")):
             if not is_envvar_true("WEBSITE_PLACEHOLDER_MODE"):
-                logger.info(f"Not a placeholder. Loading customers"
-                            " dependencies")
+                logger.info("Not a placeholder. Loading customer dependencies")
             DependencyManager.prioritize_customer_dependencies()
 
         if DependencyManager.is_in_linux_consumption():

--- a/azure_functions_worker/logging.py
+++ b/azure_functions_worker/logging.py
@@ -11,11 +11,12 @@ from typing import Optional
 CONSOLE_LOG_PREFIX = "LanguageWorkerConsoleLog"
 SYSTEM_LOG_PREFIX = "azure_functions_worker"
 SDK_LOG_PREFIX = "azure.functions"
+SYSTEM_ERROR_LOG_PREFIX = "azure_functions_worker_errors"
 
 
-logger: logging.Logger = logging.getLogger('azure_functions_worker')
+logger: logging.Logger = logging.getLogger(SYSTEM_LOG_PREFIX)
 error_logger: logging.Logger = (
-    logging.getLogger('azure_functions_worker_errors'))
+    logging.getLogger(SYSTEM_ERROR_LOG_PREFIX))
 
 handler: Optional[logging.Handler] = None
 error_handler: Optional[logging.Handler] = None

--- a/azure_functions_worker/utils/dependency.py
+++ b/azure_functions_worker/utils/dependency.py
@@ -8,7 +8,7 @@ import sys
 from types import ModuleType
 from typing import List, Optional
 
-from azure_functions_worker.utils.common import is_true_like
+from azure_functions_worker.utils.common import is_true_like, is_envvar_true
 from ..constants import (
     AZURE_WEBJOBS_SCRIPT_ROOT,
     CONTAINER_NAME,
@@ -75,13 +75,22 @@ class DependencyManager:
         return CONTAINER_NAME in os.environ
 
     @classmethod
+    def should_load_cx_dependencies(cls):
+        """
+        Customer dependencies should be loaded when dependency
+         isolation is enabled and
+         1) App is a dedicated app
+         2) App is linux consumption but not in placeholder mode.
+         This can happen when the worker restarts for any reason
+         (OOM, timeouts etc) and env reload request is not called.
+        """
+        return not (DependencyManager.is_in_linux_consumption()
+                    and is_envvar_true("WEBSITE_PLACEHOLDER_MODE"))
+
+    @classmethod
     @enable_feature_by(
         flag=PYTHON_ISOLATE_WORKER_DEPENDENCIES,
-        flag_default=(
-            PYTHON_ISOLATE_WORKER_DEPENDENCIES_DEFAULT_310 if
-            is_python_version('3.10') else
-            PYTHON_ISOLATE_WORKER_DEPENDENCIES_DEFAULT
-        )
+        flag_default=PYTHON_ISOLATE_WORKER_DEPENDENCIES_DEFAULT
     )
     def use_worker_dependencies(cls):
         """Switch the sys.path and ensure the worker imports are loaded from
@@ -109,11 +118,7 @@ class DependencyManager:
     @classmethod
     @enable_feature_by(
         flag=PYTHON_ISOLATE_WORKER_DEPENDENCIES,
-        flag_default=(
-            PYTHON_ISOLATE_WORKER_DEPENDENCIES_DEFAULT_310 if
-            is_python_version('3.10') else
-            PYTHON_ISOLATE_WORKER_DEPENDENCIES_DEFAULT
-        )
+        flag_default=PYTHON_ISOLATE_WORKER_DEPENDENCIES_DEFAULT
     )
     def prioritize_customer_dependencies(cls, cx_working_dir=None):
         """Switch the sys.path and ensure the customer's code import are loaded
@@ -147,9 +152,12 @@ class DependencyManager:
             cx_deps_path = cls.cx_deps_path
 
         logger.info(
-            'Applying prioritize_customer_dependencies: worker_dependencies: '
-            '%s, customer_dependencies: %s, working_directory: %s',
-            cls.worker_deps_path, cx_deps_path, working_directory)
+            'Applying prioritize_customer_dependencies: '
+            'worker_dependencies_path: %s, customer_dependencies_path: %s, '
+            'working_directory: %s, Linux Consumption: %s, Placeholder: %s',
+            cls.worker_deps_path, cx_deps_path, working_directory,
+            DependencyManager.is_in_linux_consumption(),
+            is_envvar_true("WEBSITE_PLACEHOLDER_MODE"))
 
         cls._remove_from_sys_path(cls.worker_deps_path)
         cls._add_to_sys_path(cls.cx_deps_path, True)
@@ -175,6 +183,9 @@ class DependencyManager:
 
         Depends on the PYTHON_ISOLATE_WORKER_DEPENDENCIES, the actual behavior
         differs.
+
+        This is called only when placeholder mode is true. In the case of a
+        worker restart, this will not be called.
 
         Parameters
         ----------

--- a/tests/consumption_tests/test_linux_consumption.py
+++ b/tests/consumption_tests/test_linux_consumption.py
@@ -298,7 +298,6 @@ class TestLinuxConsumption(TestCase):
 
             sleep(2)
             logs = ctrl.get_container_logs()
-            self.assertIn('WEBSITE_PLACEHOLDER_MODE: 0', logs)
             self.assertNotIn("Failure Exception: ModuleNotFoundError",
                              logs)
 

--- a/tests/consumption_tests/test_linux_consumption.py
+++ b/tests/consumption_tests/test_linux_consumption.py
@@ -272,7 +272,15 @@ class TestLinuxConsumption(TestCase):
 
             sleep(2)
             logs = ctrl.get_container_logs()
-            self.assertIn('WEBSITE_PLACEHOLDER_MODE: 0', logs)
+            self.assertRegex(
+                logs,
+                r"Applying prioritize_customer_dependencies: "
+                r"worker_dependencies_path: \/azure-functions-host\/"
+                r"workers\/python\/.*?\/LINUX\/X64,"
+                r" customer_dependencies_path: \/home\/site\/wwwroot\/"
+                r"\.python_packages\/lib\/site-packages, working_directory:"
+                r" \/home\/site\/wwwroot, Linux Consumption: True,"
+                r" Placeholder: False")
             self.assertNotIn("Failure Exception: ModuleNotFoundError",
                              logs)
 
@@ -298,6 +306,16 @@ class TestLinuxConsumption(TestCase):
 
             sleep(2)
             logs = ctrl.get_container_logs()
+            self.assertRegex(
+                logs,
+                r"Applying prioritize_customer_dependencies: "
+                r"worker_dependencies_path: \/azure-functions-host\/"
+                r"workers\/python\/.*?\/LINUX\/X64,"
+                r" customer_dependencies_path: \/home\/site\/wwwroot\/"
+                r"\.python_packages\/lib\/site-packages, working_directory:"
+                r" \/home\/site\/wwwroot, Linux Consumption: True,"
+                r" Placeholder: False")
+
             self.assertNotIn("Failure Exception: ModuleNotFoundError",
                              logs)
 

--- a/tests/consumption_tests/test_linux_consumption.py
+++ b/tests/consumption_tests/test_linux_consumption.py
@@ -294,7 +294,7 @@ class TestLinuxConsumption(TestCase):
             })
             req = Request('GET', f'{ctrl.url}/api/httptrigger')
             resp = ctrl.send_request(req)
-            self.assertEqual(resp.status_code, 502)
+            self.assertEqual(resp.status_code, 500)
 
             sleep(2)
             logs = ctrl.get_container_logs()

--- a/tests/consumption_tests/test_linux_consumption.py
+++ b/tests/consumption_tests/test_linux_consumption.py
@@ -4,7 +4,6 @@ import os
 import sys
 from time import sleep
 from unittest import TestCase, skipIf
-from unittest.mock import patch
 
 from requests import Request
 

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -606,8 +606,7 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         self.mock_version_info.stop()
 
     async def test_dispatcher_load_azfunc_in_init(self):
-        """Test if the dispatcher's log can be flushed out during worker
-        initialization
+        """Test if azure functions is loaded during init
         """
         async with self._ctrl as host:
             r = await host.init_worker('4.15.1')
@@ -620,8 +619,7 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         self.assertIn("azure.functions", sys.modules)
 
     async def test_dispatcher_load_modules(self):
-        """Test if the dispatcher's log can be flushed out during worker
-        initialization
+        """Test modules are loaded in placeholder mode
         """
         os.environ["CONTAINER_NAME"] = "test"
         async with self._ctrl as host:

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -626,14 +626,15 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         # Dedicated Apps where placeholder mode is not set
         async with self._ctrl as host:
             r = await host.init_worker('4.15.1')
-            self.assertEqual(
-                len([log for log in r.logs if log.message.startswith(
-                    'Applying prioritize_customer_dependencies:'
-                )]),
-                1
+            l = [log.message for log in r.logs]
+            self.assertIn(
+                "Applying prioritize_customer_dependencies: "
+                "worker_dependencies_path: , customer_dependencies_path: , "
+                "working_directory: , Linux Consumption: False,"
+                " Placeholder: False", l
             )
 
-    async def test_dispatcher_load_modules_con_app_placeholder_enabled(self):
+    async def test_dispatcher_load_modules_con_placeholder_enabled(self):
         """Test modules are loaded in consumption apps with placeholder mode
         enabled.
         """
@@ -643,11 +644,12 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         os.environ["WEBSITE_PLACEHOLDER_MODE"] = "1"
         async with self._ctrl as host:
             r = await host.init_worker('4.15.1')
-            self.assertEqual(
-                len([log for log in r.logs if log.message.startswith(
-                    'Applying prioritize_customer_dependencies:'
-                )]),
-                0
+            l = [log.message for log in r.logs]
+            self.assertNotIn(
+                "Applying prioritize_customer_dependencies: "
+                "worker_dependencies_path: , customer_dependencies_path: , "
+                "working_directory: , Linux Consumption: True,"
+                " Placeholder: True", l
             )
 
     async def test_dispatcher_load_modules_con_app_placeholder_disabled(self):
@@ -661,9 +663,10 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         os.environ["CONTAINER_NAME"] = "test"
         async with self._ctrl as host:
             r = await host.init_worker('4.15.1')
-            self.assertEqual(
-                len([log for log in r.logs if log.message.startswith(
-                    'Applying prioritize_customer_dependencies:'
-                )]),
-                1
-            )
+            l = [log.message for log in r.logs]
+            self.assertIn(
+                "Applying prioritize_customer_dependencies: "
+                "worker_dependencies_path: , customer_dependencies_path: , "
+                "working_directory: , Linux Consumption: True,"
+                " Placeholder: False", l
+                )

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -626,12 +626,12 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         # Dedicated Apps where placeholder mode is not set
         async with self._ctrl as host:
             r = await host.init_worker('4.15.1')
-            l = [log.message for log in r.logs]
+            logs = [log.message for log in r.logs]
             self.assertIn(
                 "Applying prioritize_customer_dependencies: "
                 "worker_dependencies_path: , customer_dependencies_path: , "
                 "working_directory: , Linux Consumption: False,"
-                " Placeholder: False", l
+                " Placeholder: False", logs
             )
 
     async def test_dispatcher_load_modules_con_placeholder_enabled(self):
@@ -644,13 +644,11 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         os.environ["WEBSITE_PLACEHOLDER_MODE"] = "1"
         async with self._ctrl as host:
             r = await host.init_worker('4.15.1')
-            l = [log.message for log in r.logs]
+            logs = [log.message for log in r.logs]
             self.assertNotIn(
                 "Applying prioritize_customer_dependencies: "
                 "worker_dependencies_path: , customer_dependencies_path: , "
-                "working_directory: , Linux Consumption: True,"
-                " Placeholder: True", l
-            )
+                "working_directory: , Linux Consumption: True,", logs)
 
     async def test_dispatcher_load_modules_con_app_placeholder_disabled(self):
         """Test modules are loaded in consumption apps with placeholder mode
@@ -663,10 +661,9 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
         os.environ["CONTAINER_NAME"] = "test"
         async with self._ctrl as host:
             r = await host.init_worker('4.15.1')
-            l = [log.message for log in r.logs]
+            logs = [log.message for log in r.logs]
             self.assertIn(
                 "Applying prioritize_customer_dependencies: "
                 "worker_dependencies_path: , customer_dependencies_path: , "
                 "working_directory: , Linux Consumption: True,"
-                " Placeholder: False", l
-                )
+                " Placeholder: False", logs)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
In linux consumption, when the host restarts the python worker due to any reason (timeout/OOM..), the host does not send an EnvironmentReload request since it assumes that the container has already been specialized. Due to this customer modules are not loaded and that causes the function app to fail with ModuleNotFound errors. 
Fix here is to load customer modules when the container is not in placeholder mode for linux consumption. 

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
