### PR TITLE
Moving function indexing to init request

### DIFF
--- a/azure_functions_worker/constants.py
+++ b/azure_functions_worker/constants.py
@@ -55,3 +55,6 @@ RETRY_POLICY = "retry_policy"
 
 # Paths
 CUSTOMER_PACKAGES_PATH = "/home/site/wwwroot/.python_packages/lib/site-packages"
+
+# Flag to index functions in handle init request
+INIT_INDEXING = "INIT_INDEXING"

--- a/azure_functions_worker/constants.py
+++ b/azure_functions_worker/constants.py
@@ -57,6 +57,6 @@ RETRY_POLICY = "retry_policy"
 CUSTOMER_PACKAGES_PATH = "/home/site/wwwroot/.python_packages/lib/site-packages"
 
 # Flag to index functions in handle init request
-PYTHON_ENABLE_INIT_INDEXING = "ENABLE_INIT_INDEXING"
+PYTHON_ENABLE_INIT_INDEXING = "PYTHON_ENABLE_INIT_INDEXING"
 
 METADATA_PROPERTIES_WORKER_INDEXED = "worker_indexed"

--- a/azure_functions_worker/constants.py
+++ b/azure_functions_worker/constants.py
@@ -57,6 +57,6 @@ RETRY_POLICY = "retry_policy"
 CUSTOMER_PACKAGES_PATH = "/home/site/wwwroot/.python_packages/lib/site-packages"
 
 # Flag to index functions in handle init request
-ENABLE_INIT_INDEXING = "ENABLE_INIT_INDEXING"
+PYTHON_ENABLE_INIT_INDEXING = "ENABLE_INIT_INDEXING"
 
 METADATA_PROPERTIES_WORKER_INDEXED = "worker_indexed"

--- a/azure_functions_worker/constants.py
+++ b/azure_functions_worker/constants.py
@@ -57,4 +57,4 @@ RETRY_POLICY = "retry_policy"
 CUSTOMER_PACKAGES_PATH = "/home/site/wwwroot/.python_packages/lib/site-packages"
 
 # Flag to index functions in handle init request
-INIT_INDEXING = "INIT_INDEXING"
+ENABLE_INIT_INDEXING = "ENABLE_INIT_INDEXING"

--- a/azure_functions_worker/constants.py
+++ b/azure_functions_worker/constants.py
@@ -58,3 +58,5 @@ CUSTOMER_PACKAGES_PATH = "/home/site/wwwroot/.python_packages/lib/site-packages"
 
 # Flag to index functions in handle init request
 ENABLE_INIT_INDEXING = "ENABLE_INIT_INDEXING"
+
+METADATA_PROPERTIES_WORKER_INDEXED = "worker_indexed"

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -30,7 +30,7 @@ from .constants import (PYTHON_ROLLBACK_CWD_PATH,
                         PYTHON_ENABLE_DEBUG_LOGGING,
                         PYTHON_SCRIPT_FILE_NAME,
                         PYTHON_SCRIPT_FILE_NAME_DEFAULT,
-                        PYTHON_LANGUAGE_RUNTIME, ENABLE_INIT_INDEXING,
+                        PYTHON_LANGUAGE_RUNTIME, PYTHON_ENABLE_INIT_INDEXING,
                         METADATA_PROPERTIES_WORKER_INDEXED)
 from .extension import ExtensionManager
 from .logging import disable_console_logging, enable_console_logging
@@ -301,7 +301,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         # dictionary which will be later used in the invocation request
         bindings.load_binding_registry()
 
-        if is_envvar_true(ENABLE_INIT_INDEXING):
+        if is_envvar_true(PYTHON_ENABLE_INIT_INDEXING):
             self.load_function_metadata(
                 worker_init_request.function_app_directory,
                 caller_info="worker_init_request")
@@ -353,7 +353,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         metadata_request = request.functions_metadata_request
         function_app_directory = metadata_request.function_app_directory
 
-        if not is_envvar_true(ENABLE_INIT_INDEXING):
+        if not is_envvar_true(PYTHON_ENABLE_INIT_INDEXING):
             self.load_function_metadata(
                 function_app_directory,
                 caller_info="functions_metadata_request")
@@ -401,7 +401,7 @@ class Dispatcher(metaclass=DispatcherMeta):
                     # calling the metadata request. In this case we index the
                     # function and update the workers registry
 
-                    if not is_envvar_true(ENABLE_INIT_INDEXING):
+                    if not is_envvar_true(PYTHON_ENABLE_INIT_INDEXING):
                         self.load_function_metadata(
                             function_app_directory,
                             caller_info="functions_load_request")
@@ -623,7 +623,7 @@ class Dispatcher(metaclass=DispatcherMeta):
             # reload_customer_libraries call clears the registry
             bindings.load_binding_registry()
 
-            if is_envvar_true(ENABLE_INIT_INDEXING):
+            if is_envvar_true(PYTHON_ENABLE_INIT_INDEXING):
                 self.load_function_metadata(
                     directory,
                     caller_info=sys._getframe().f_code.co_name)

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -324,8 +324,8 @@ class Dispatcher(metaclass=DispatcherMeta):
     def get_function_metadata(self, directory, caller_info):
         """
         This method is called to index the functions in the function app directory
-        and save the results in function_metadata_result or 
-        function_metadata_exception in case of an exception. 
+        and save the results in function_metadata_result or
+        function_metadata_exception in case of an exception.
         """
         script_file_name = get_app_setting(
             setting=PYTHON_SCRIPT_FILE_NAME,

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -397,17 +397,15 @@ class Dispatcher(metaclass=DispatcherMeta):
         function_metadata = func_request.metadata
         function_name = function_metadata.name
         function_app_directory = function_metadata.directory
-        function_already_indexed = self._functions.get_function(function_id)
 
         logger.info(
             'Received WorkerLoadRequest, request ID %s, function_id: %s,'
-            'function_name: %s, function_already_indexed: %s',
-            self.request_id, function_id, function_name,
-            function_already_indexed)
+            'function_name: %s',
+            self.request_id, function_id, function_name)
 
         programming_model = "V2"
         try:
-            if not function_already_indexed:
+            if not self._functions.get_function(function_id):
 
                 if function_metadata.properties.get(
                         METADATA_PROPERTIES_WORKER_INDEXED, False):
@@ -416,13 +414,12 @@ class Dispatcher(metaclass=DispatcherMeta):
                     # calling the metadata request. In this case we index the
                     # function and update the workers registry
 
-                    if not is_envvar_true(PYTHON_ENABLE_INIT_INDEXING):
-                        try:
-                            self.load_function_metadata(
-                                function_app_directory,
-                                caller_info="functions_load_request")
-                        except Exception as ex:
-                            self._function_metadata_exception = ex
+                    try:
+                        self.load_function_metadata(
+                            function_app_directory,
+                            caller_info="functions_load_request")
+                    except Exception as ex:
+                        self._function_metadata_exception = ex
 
                     # For the second worker, if there was an exception in
                     # indexing, we raise it here

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -302,8 +302,9 @@ class Dispatcher(metaclass=DispatcherMeta):
         bindings.load_binding_registry()
 
         if is_envvar_true(ENABLE_INIT_INDEXING):
-            self.get_function_metadata(directory,
-                                       caller_info=sys._getframe().f_code.co_name)
+            self.get_function_metadata(
+                directory,
+                caller_info=sys._getframe().f_code.co_name)
 
         return protos.StreamingMessage(
             request_id=self.request_id,
@@ -323,8 +324,8 @@ class Dispatcher(metaclass=DispatcherMeta):
 
     def get_function_metadata(self, directory, caller_info):
         """
-        This method is called to index the functions in the function app directory
-        and save the results in function_metadata_result or
+        This method is called to index the functions in the function app
+        directory and save the results in function_metadata_result or
         function_metadata_exception in case of an exception.
         """
         script_file_name = get_app_setting(
@@ -340,7 +341,8 @@ class Dispatcher(metaclass=DispatcherMeta):
             validate_script_file_name(script_file_name)
             function_path = os.path.join(directory, script_file_name)
 
-            self.function_metadata_result = self.index_functions(function_path) \
+            self.function_metadata_result = (
+                self.index_functions(function_path)) \
                 if os.path.exists(function_path) else None
 
         except Exception as ex:
@@ -351,8 +353,9 @@ class Dispatcher(metaclass=DispatcherMeta):
         directory = metadata_request.function_app_directory
 
         if not is_envvar_true(ENABLE_INIT_INDEXING):
-            self.get_function_metadata(directory,
-                                       caller_info=sys._getframe().f_code.co_name)
+            self.get_function_metadata(
+                directory,
+                caller_info=sys._getframe().f_code.co_name)
 
         if self.function_metadata_exception:
             return protos.StreamingMessage(
@@ -381,7 +384,8 @@ class Dispatcher(metaclass=DispatcherMeta):
 
         logger.info(
             'Received WorkerLoadRequest, request ID %s, function_id: %s,'
-            'function_name: %s,', self.request_id, function_id, function_name)
+            'function_name: %s,',
+            self.request_id, function_id, function_name)
 
         programming_model = "V2"
         try:
@@ -576,6 +580,7 @@ class Dispatcher(metaclass=DispatcherMeta):
 
             func_env_reload_request = \
                 request.function_environment_reload_request
+            directory = func_env_reload_request.function_app_directory
 
             # Append function project root to module finding sys.path
             if func_env_reload_request.function_app_directory:
@@ -601,13 +606,16 @@ class Dispatcher(metaclass=DispatcherMeta):
                 root_logger.setLevel(logging.DEBUG)
 
             # Reload azure google namespaces
-            DependencyManager.reload_customer_libraries(
-                func_env_reload_request.function_app_directory
-            )
+            DependencyManager.reload_customer_libraries(directory)
 
             # calling load_binding_registry again since the
             # reload_customer_libraries call clears the registry
             bindings.load_binding_registry()
+
+            if is_envvar_true(ENABLE_INIT_INDEXING):
+                self.get_function_metadata(
+                    directory,
+                    caller_info=sys._getframe().f_code.co_name)
 
             # Change function app directory
             if getattr(func_env_reload_request,

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -276,6 +276,7 @@ class Dispatcher(metaclass=DispatcherMeta):
                     )
 
         worker_init_request = request.worker_init_request
+        directory = worker_init_request.function_app_directory
         host_capabilities = worker_init_request.capabilities
         if constants.FUNCTION_DATA_CACHE in host_capabilities:
             val = host_capabilities[constants.FUNCTION_DATA_CACHE]
@@ -301,7 +302,8 @@ class Dispatcher(metaclass=DispatcherMeta):
         bindings.load_binding_registry()
 
         if is_envvar_true(INIT_INDEXING):
-            self.get_function_metadata(worker_init_request)
+            self.get_function_metadata(directory,
+                                       caller_info=sys._getframe().f_code.co_name)
 
         return protos.StreamingMessage(
             request_id=self.request_id,

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -365,13 +365,14 @@ class Dispatcher(metaclass=DispatcherMeta):
                         status=protos.StatusResult.Failure,
                         exception=self.function_metadata_exception)))
         else:
-            fmr = self.function_metadata_result
+            metadata_result = self.function_metadata_result
 
             return protos.StreamingMessage(
                 request_id=request.request_id,
                 function_metadata_response=protos.FunctionMetadataResponse(
-                    use_default_metadata_indexing=False if fmr else True,
-                    function_metadata_results=fmr,
+                    use_default_metadata_indexing=False if metadata_result else
+                    True,
+                    function_metadata_results=metadata_result,
                     result=protos.StatusResult(
                         status=protos.StatusResult.Success)))
 

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -30,7 +30,7 @@ from .constants import (PYTHON_ROLLBACK_CWD_PATH,
                         PYTHON_ENABLE_DEBUG_LOGGING,
                         PYTHON_SCRIPT_FILE_NAME,
                         PYTHON_SCRIPT_FILE_NAME_DEFAULT,
-                        PYTHON_LANGUAGE_RUNTIME, INIT_INDEXING)
+                        PYTHON_LANGUAGE_RUNTIME, ENABLE_INIT_INDEXING)
 from .extension import ExtensionManager
 from .logging import disable_console_logging, enable_console_logging
 from .logging import (logger, error_logger, is_system_log_category,
@@ -301,7 +301,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         # dictionary which will be later used in the invocation request
         bindings.load_binding_registry()
 
-        if is_envvar_true(INIT_INDEXING):
+        if is_envvar_true(ENABLE_INIT_INDEXING):
             self.get_function_metadata(directory,
                                        caller_info=sys._getframe().f_code.co_name)
 
@@ -322,6 +322,11 @@ class Dispatcher(metaclass=DispatcherMeta):
             worker_status_response=protos.WorkerStatusResponse())
 
     def get_function_metadata(self, directory, caller_info):
+        """
+        This method is called to index the functions in the function app directory
+        and save the results in function_metadata_result or 
+        function_metadata_exception in case of an exception. 
+        """
         script_file_name = get_app_setting(
             setting=PYTHON_SCRIPT_FILE_NAME,
             default_value=f'{PYTHON_SCRIPT_FILE_NAME_DEFAULT}')
@@ -345,7 +350,7 @@ class Dispatcher(metaclass=DispatcherMeta):
         metadata_request = request.functions_metadata_request
         directory = metadata_request.function_app_directory
 
-        if not is_envvar_true(INIT_INDEXING):
+        if not is_envvar_true(ENABLE_INIT_INDEXING):
             self.get_function_metadata(directory,
                                        caller_info=sys._getframe().f_code.co_name)
 
@@ -383,7 +388,7 @@ class Dispatcher(metaclass=DispatcherMeta):
             if not self._functions.get_function(function_id):
 
                 if function_metadata.properties.get("worker_indexed", False)\
-                        and not is_envvar_true(INIT_INDEXING):
+                        and not is_envvar_true(ENABLE_INIT_INDEXING):
                     # This is for the second worker and above where the worker
                     # indexing is enabled and load request is called without
                     # calling the metadata request. In this case we index the

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -327,7 +327,8 @@ class Dispatcher(metaclass=DispatcherMeta):
             default_value=f'{PYTHON_SCRIPT_FILE_NAME_DEFAULT}')
 
         logger.info(
-            'Received WorkerMetadataRequest from %s, request ID %s, script_file_name: %s',
+            'Received WorkerMetadataRequest from %s, request ID %s, '
+            'script_file_name: %s',
             caller_info, self.request_id, script_file_name)
 
         try:
@@ -389,7 +390,7 @@ class Dispatcher(metaclass=DispatcherMeta):
                     # function and update the workers registry
 
                     self.get_function_metadata(directory,
-                                               caller_info=sys._getframe().f_code.co_name)
+                                               sys._getframe().f_code.co_name)
                 else:
                     # legacy function
                     programming_model = "V1"

--- a/azure_functions_worker/loader.py
+++ b/azure_functions_worker/loader.py
@@ -19,7 +19,7 @@ from .bindings.retrycontext import RetryPolicy
 from .utils.common import get_app_setting
 from .constants import MODULE_NOT_FOUND_TS_URL, PYTHON_SCRIPT_FILE_NAME, \
     PYTHON_SCRIPT_FILE_NAME_DEFAULT, PYTHON_LANGUAGE_RUNTIME, \
-    CUSTOMER_PACKAGES_PATH, RETRY_POLICY
+    CUSTOMER_PACKAGES_PATH, RETRY_POLICY, METADATA_PROPERTIES_WORKER_INDEXED
 from .logging import logger
 from .utils.wrappers import attach_message_to_exception
 
@@ -142,7 +142,7 @@ def process_indexed_function(functions_registry: functions.Registry,
             bindings=binding_protos,
             raw_bindings=indexed_function.get_raw_bindings(),
             retry_options=retry_protos,
-            properties={"worker_indexed": "True"})
+            properties={METADATA_PROPERTIES_WORKER_INDEXED: "True"})
 
         fx_metadata_results.append(function_metadata)
 
@@ -218,7 +218,6 @@ def load_function(name: str, directory: str, script_file: str,
                f'{os.path.exists(CUSTOMER_PACKAGES_PATH)}')
 def index_function_app(function_path: str):
     module_name = pathlib.Path(function_path).stem
-    logger.info(f'Loading module {module_name}')
     imported_module = importlib.import_module(module_name)
 
     from azure.functions import FunctionRegister

--- a/azure_functions_worker/loader.py
+++ b/azure_functions_worker/loader.py
@@ -218,6 +218,7 @@ def load_function(name: str, directory: str, script_file: str,
                f'{os.path.exists(CUSTOMER_PACKAGES_PATH)}')
 def index_function_app(function_path: str):
     module_name = pathlib.Path(function_path).stem
+    logger.info(f'Loading module {module_name}')
     imported_module = importlib.import_module(module_name)
 
     from azure.functions import FunctionRegister

--- a/azure_functions_worker/utils/app_setting_manager.py
+++ b/azure_functions_worker/utils/app_setting_manager.py
@@ -11,7 +11,7 @@ from ..constants import (PYTHON_ROLLBACK_CWD_PATH,
                          PYTHON_ENABLE_WORKER_EXTENSIONS_DEFAULT_39,
                          PYTHON_ENABLE_DEBUG_LOGGING,
                          FUNCTIONS_WORKER_SHARED_MEMORY_DATA_TRANSFER_ENABLED,
-                         PYTHON_SCRIPT_FILE_NAME)
+                         PYTHON_SCRIPT_FILE_NAME, PYTHON_ENABLE_INIT_INDEXING)
 
 
 def get_python_appsetting_state():
@@ -23,7 +23,8 @@ def get_python_appsetting_state():
          PYTHON_ENABLE_DEBUG_LOGGING,
          PYTHON_ENABLE_WORKER_EXTENSIONS,
          FUNCTIONS_WORKER_SHARED_MEMORY_DATA_TRANSFER_ENABLED,
-         PYTHON_SCRIPT_FILE_NAME]
+         PYTHON_SCRIPT_FILE_NAME,
+         PYTHON_ENABLE_INIT_INDEXING]
 
     app_setting_states = "".join(
         f"{app_setting}: {current_vars[app_setting]} | "

--- a/azure_functions_worker/utils/common.py
+++ b/azure_functions_worker/utils/common.py
@@ -153,4 +153,3 @@ def validate_script_file_name(file_name: str):
     pattern = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_\-]*\.py$')
     if not pattern.match(file_name):
         raise InvalidFileNameError(file_name)
-    return True

--- a/tests/consumption_tests/test_linux_consumption.py
+++ b/tests/consumption_tests/test_linux_consumption.py
@@ -7,7 +7,7 @@ from unittest import TestCase, skipIf
 
 from requests import Request
 
-from azure_functions_worker.constants import ENABLE_INIT_INDEXING, \
+from azure_functions_worker.constants import PYTHON_ENABLE_INIT_INDEXING, \
     PYTHON_ENABLE_WORKER_EXTENSIONS, PYTHON_ISOLATE_WORKER_DEPENDENCIES, \
     PYTHON_ENABLE_DEBUG_LOGGING
 from tests.utils.testutils_lc import (
@@ -262,7 +262,7 @@ class TestLinuxConsumption(TestCase):
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url("Opencensus"),
                 PYTHON_ENABLE_WORKER_EXTENSIONS: "1",
-                ENABLE_INIT_INDEXING: "true"
+                PYTHON_ENABLE_INIT_INDEXING: "true"
             })
             req = Request('GET', f'{ctrl.url}/api/opencensus')
             resp = ctrl.send_request(req)

--- a/tests/consumption_tests/test_linux_consumption.py
+++ b/tests/consumption_tests/test_linux_consumption.py
@@ -7,6 +7,9 @@ from unittest import TestCase, skipIf
 
 from requests import Request
 
+from azure_functions_worker.constants import ENABLE_INIT_INDEXING, \
+    PYTHON_ENABLE_WORKER_EXTENSIONS, PYTHON_ISOLATE_WORKER_DEPENDENCIES, \
+    PYTHON_ENABLE_DEBUG_LOGGING
 from tests.utils.testutils_lc import (
     LinuxConsumptionWebHostController
 )
@@ -107,7 +110,7 @@ class TestLinuxConsumption(TestCase):
             ctrl.assign_container(env={
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url("NewProtobuf"),
-                "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
+                PYTHON_ISOLATE_WORKER_DEPENDENCIES: "1"
             })
             req = Request('GET', f'{ctrl.url}/api/HttpTrigger')
             resp = ctrl.send_request(req)
@@ -137,7 +140,7 @@ class TestLinuxConsumption(TestCase):
             ctrl.assign_container(env={
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url("OldProtobuf"),
-                "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
+                PYTHON_ISOLATE_WORKER_DEPENDENCIES: "1"
             })
             req = Request('GET', f'{ctrl.url}/api/HttpTrigger')
             resp = ctrl.send_request(req)
@@ -189,7 +192,7 @@ class TestLinuxConsumption(TestCase):
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url(
                     "EnableDebugLogging"),
-                "PYTHON_ENABLE_DEBUG_LOGGING": "1"
+                PYTHON_ENABLE_DEBUG_LOGGING: "1"
             })
             req = Request('GET', f'{ctrl.url}/api/HttpTrigger1')
             resp = ctrl.send_request(req)
@@ -218,7 +221,7 @@ class TestLinuxConsumption(TestCase):
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url(
                     "PinningFunctions"),
-                "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1",
+                PYTHON_ISOLATE_WORKER_DEPENDENCIES: "1",
             })
             req = Request('GET', f'{ctrl.url}/api/HttpTrigger1')
             resp = ctrl.send_request(req)
@@ -232,8 +235,7 @@ class TestLinuxConsumption(TestCase):
         """A function app with extensions enabled containing the
          following libraries:
 
-        azure-functions, azure-eventhub, azure-storage-blob, numpy,
-        cryptography, pyodbc, requests
+        azure-functions, opencensus
 
         should return 200 after importing all libraries.
         """
@@ -242,8 +244,25 @@ class TestLinuxConsumption(TestCase):
             ctrl.assign_container(env={
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url("Opencensus"),
-                "PYTHON_ENABLE_WORKER_EXTENSIONS": "1",
-                "AzureWebJobsFeatureFlags": "EnableWorkerIndexing"
+                PYTHON_ENABLE_WORKER_EXTENSIONS: "1"
+            })
+            req = Request('GET', f'{ctrl.url}/api/opencensus')
+            resp = ctrl.send_request(req)
+            self.assertEqual(resp.status_code, 200)
+
+    @skipIf(sys.version_info.minor != 10,
+            "This is testing only for python310")
+    def test_opencensus_with_extensions_enabled_init_indexing(self):
+        """
+        A function app with init indexing enabled
+        """
+        with LinuxConsumptionWebHostController(_DEFAULT_HOST_VERSION,
+                                               self._py_version) as ctrl:
+            ctrl.assign_container(env={
+                "AzureWebJobsStorage": self._storage,
+                "SCM_RUN_FROM_PACKAGE": self._get_blob_url("Opencensus"),
+                PYTHON_ENABLE_WORKER_EXTENSIONS: "1",
+                ENABLE_INIT_INDEXING: "true"
             })
             req = Request('GET', f'{ctrl.url}/api/opencensus')
             resp = ctrl.send_request(req)
@@ -263,8 +282,7 @@ class TestLinuxConsumption(TestCase):
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url(
                     "TimeoutError"),
-                "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1",
-                "AzureWebJobsFeatureFlags": "EnableWorkerIndexing"
+                PYTHON_ISOLATE_WORKER_DEPENDENCIES: "1"
             })
             req = Request('GET', f'{ctrl.url}/api/hello')
             resp = ctrl.send_request(req)
@@ -297,8 +315,7 @@ class TestLinuxConsumption(TestCase):
                 "AzureWebJobsStorage": self._storage,
                 "SCM_RUN_FROM_PACKAGE": self._get_blob_url(
                     "OOMError"),
-                "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1",
-                "AzureWebJobsFeatureFlags": "EnableWorkerIndexing"
+                PYTHON_ISOLATE_WORKER_DEPENDENCIES: "1"
             })
             req = Request('GET', f'{ctrl.url}/api/httptrigger')
             resp = ctrl.send_request(req)

--- a/tests/endtoend/test_http_functions.py
+++ b/tests/endtoend/test_http_functions.py
@@ -34,8 +34,7 @@ class TestHttpFunctions(testutils.WebHostTestCase):
 
     @classmethod
     def get_script_dir(cls):
-        return testutils.E2E_TESTS_FOLDER / 'http_functions' / \
-            'http_functions_stein'
+        return testutils.E2E_TESTS_FOLDER / 'http_functions'
 
     @testutils.retryable_test(3, 5)
     def test_function_index_page_should_return_ok(self):

--- a/tests/endtoend/test_http_functions.py
+++ b/tests/endtoend/test_http_functions.py
@@ -205,7 +205,7 @@ class TestCommonLibsHttpFunctionsStein(TestCommonLibsHttpFunctions):
                                             'common_libs_functions_stein'
 
 
-class TestHttpFunctionsWithInitIndexing(testutils.WebHostTestCase):
+class TestHttpFunctionsWithInitIndexing(TestHttpFunctions):
 
     @classmethod
     def setUpClass(cls):
@@ -218,22 +218,19 @@ class TestHttpFunctionsWithInitIndexing(testutils.WebHostTestCase):
         os.environ.pop('INIT_INDEXING')
         super().tearDownClass()
 
-    @classmethod
-    def get_script_dir(cls):
-        return testutils.E2E_TESTS_FOLDER / 'http_functions'
 
-    def test_default_http_template_should_accept_body(self):
-        """Test if the azure.functions SDK is able to deserialize http body
-        and pass it to default template
-        """
-        r = self.webhost.request('POST', 'default_template',
-                                 data='{ "name": "body" }'.encode('utf-8'),
-                                 timeout=REQUEST_TIMEOUT_SEC)
-        self.assertTrue(r.ok)
-        self.assertEqual(
-            r.content,
-            b'Hello, body. This HTTP triggered function executed successfully.'
-        )
+class TestHttpFunctionsV2WithInitIndexing(TestHttpFunctionsStein):
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ["INIT_INDEXING"] = "1"
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove the PYTHON_SCRIPT_FILE_NAME environment variable
+        os.environ.pop('INIT_INDEXING')
+        super().tearDownClass()
 
 
 class TestUserThreadLoggingHttpFunctions(testutils.WebHostTestCase):

--- a/tests/endtoend/test_http_functions.py
+++ b/tests/endtoend/test_http_functions.py
@@ -34,7 +34,8 @@ class TestHttpFunctions(testutils.WebHostTestCase):
 
     @classmethod
     def get_script_dir(cls):
-        return testutils.E2E_TESTS_FOLDER / 'http_functions'
+        return testutils.E2E_TESTS_FOLDER / 'http_functions' / \
+            'http_functions_stein'
 
     @testutils.retryable_test(3, 5)
     def test_function_index_page_should_return_ok(self):

--- a/tests/endtoend/test_http_functions.py
+++ b/tests/endtoend/test_http_functions.py
@@ -205,6 +205,37 @@ class TestCommonLibsHttpFunctionsStein(TestCommonLibsHttpFunctions):
                                             'common_libs_functions_stein'
 
 
+class TestHttpFunctionsWithInitIndexing(testutils.WebHostTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ["INIT_INDEXING"] = "1"
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove the PYTHON_SCRIPT_FILE_NAME environment variable
+        os.environ.pop('INIT_INDEXING')
+        super().tearDownClass()
+
+    @classmethod
+    def get_script_dir(cls):
+        return testutils.E2E_TESTS_FOLDER / 'http_functions'
+
+    def test_default_http_template_should_accept_body(self):
+        """Test if the azure.functions SDK is able to deserialize http body
+        and pass it to default template
+        """
+        r = self.webhost.request('POST', 'default_template',
+                                 data='{ "name": "body" }'.encode('utf-8'),
+                                 timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)
+        self.assertEqual(
+            r.content,
+            b'Hello, body. This HTTP triggered function executed successfully.'
+        )
+
+
 class TestUserThreadLoggingHttpFunctions(testutils.WebHostTestCase):
     """Test the Http trigger that contains logging with user threads.
 

--- a/tests/endtoend/test_http_functions.py
+++ b/tests/endtoend/test_http_functions.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import requests
 
+from azure_functions_worker.constants import PYTHON_ENABLE_INIT_INDEXING
 from tests.utils import testutils
 
 REQUEST_TIMEOUT_SEC = 5
@@ -209,13 +210,13 @@ class TestHttpFunctionsWithInitIndexing(TestHttpFunctions):
 
     @classmethod
     def setUpClass(cls):
-        os.environ["INIT_INDEXING"] = "1"
+        os.environ[PYTHON_ENABLE_INIT_INDEXING] = "1"
         super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
         # Remove the PYTHON_SCRIPT_FILE_NAME environment variable
-        os.environ.pop('INIT_INDEXING')
+        os.environ.pop(PYTHON_ENABLE_INIT_INDEXING)
         super().tearDownClass()
 
 
@@ -223,13 +224,13 @@ class TestHttpFunctionsV2WithInitIndexing(TestHttpFunctionsStein):
 
     @classmethod
     def setUpClass(cls):
-        os.environ["INIT_INDEXING"] = "1"
+        os.environ[PYTHON_ENABLE_INIT_INDEXING] = "1"
         super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
         # Remove the PYTHON_SCRIPT_FILE_NAME environment variable
-        os.environ.pop('INIT_INDEXING')
+        os.environ.pop(PYTHON_ENABLE_INIT_INDEXING)
         super().tearDownClass()
 
 

--- a/tests/endtoend/test_warmup_functions.py
+++ b/tests/endtoend/test_warmup_functions.py
@@ -2,10 +2,16 @@
 # Licensed under the MIT License.
 
 import typing
+from unittest import skipIf
 
+from azure_functions_worker.utils.common import is_envvar_true
 from tests.utils import testutils
+from tests.utils.constants import DEDICATED_DOCKER_TEST, CONSUMPTION_DOCKER_TEST
 
 
+@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
+        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
+        "Docker tests cannot call admin functions")
 class TestWarmupFunctions(testutils.WebHostTestCase):
     """Test the Warmup Trigger in the local webhost.
 
@@ -29,6 +35,9 @@ class TestWarmupFunctions(testutils.WebHostTestCase):
         self.assertEqual(host_out.count("Function App instance is warm"), 1)
 
 
+@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
+        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
+        "Docker tests cannot call admin functions")
 class TestWarmupFunctionsStein(TestWarmupFunctions):
 
     @classmethod

--- a/tests/unittests/dispatcher_functions/dispatcher_functions_stein/function_app.py
+++ b/tests/unittests/dispatcher_functions/dispatcher_functions_stein/function_app.py
@@ -1,8 +1,9 @@
 import azure.functions as func
 
-app = func.FunctionApp()
+app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
 
-@app.route()
-def main(req: func.HttpRequest):
-    pass
+@app.route(route="http_trigger")
+def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
+
+    return func.HttpResponse("Hello.")

--- a/tests/unittests/test_app_setting_manager.py
+++ b/tests/unittests/test_app_setting_manager.py
@@ -9,7 +9,7 @@ from tests.utils import testutils
 from azure_functions_worker.utils.app_setting_manager import \
     get_python_appsetting_state
 from azure_functions_worker.constants import PYTHON_THREADPOOL_THREAD_COUNT, \
-    PYTHON_ENABLE_DEBUG_LOGGING
+    PYTHON_ENABLE_DEBUG_LOGGING, PYTHON_ENABLE_INIT_INDEXING
 
 SysVersionInfo = col.namedtuple("VersionInfo", ["major", "minor", "micro",
                                                 "releaselevel", "serial"])
@@ -65,6 +65,7 @@ class TestNonDefaultAppSettingsLogs(testutils.AsyncTestCase):
         os_environ = os.environ.copy()
         os_environ[PYTHON_THREADPOOL_THREAD_COUNT] = '20'
         os_environ[PYTHON_ENABLE_DEBUG_LOGGING] = '1'
+        os_environ[PYTHON_ENABLE_INIT_INDEXING] = '1'
         cls._patch_environ = patch.dict('os.environ', os_environ)
         cls._patch_environ.start()
         super().setUpClass()
@@ -84,6 +85,8 @@ class TestNonDefaultAppSettingsLogs(testutils.AsyncTestCase):
             self.assertTrue('PYTHON_THREADPOOL_THREAD_COUNT: '
                             in log for log in r.logs)
             self.assertTrue('PYTHON_ENABLE_DEBUG_LOGGING: '
+                            in log for log in r.logs)
+            self.assertTrue('PYTHON_ENABLE_INIT_INDEXING: '
                             in log for log in r.logs)
 
     def test_get_python_appsetting_state(self):

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -13,7 +13,8 @@ from azure_functions_worker.constants import (PYTHON_THREADPOOL_THREAD_COUNT,
                                               PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT,
                                               PYTHON_THREADPOOL_THREAD_COUNT_MAX_37,
                                               PYTHON_THREADPOOL_THREAD_COUNT_MIN,
-                                              ENABLE_INIT_INDEXING)
+                                              ENABLE_INIT_INDEXING,
+                                              METADATA_PROPERTIES_WORKER_INDEXED)
 from azure_functions_worker.dispatcher import Dispatcher
 from azure_functions_worker.version import VERSION
 from tests.utils import testutils
@@ -784,8 +785,8 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.loop.run_until_complete(
             self.dispatcher._handle__worker_init_request(request))
 
-        self.assertIsNotNone(self.dispatcher.function_metadata_result)
-        self.assertIsNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNotNone(self.dispatcher._function_metadata_result)
+        self.assertIsNone(self.dispatcher._function_metadata_exception)
 
     @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'false'})
     def test_worker_init_request_with_indexing_disabled(self):
@@ -799,8 +800,8 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.loop.run_until_complete(
             self.dispatcher._handle__worker_init_request(request))
 
-        self.assertIsNone(self.dispatcher.function_metadata_result)
-        self.assertIsNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNone(self.dispatcher._function_metadata_result)
+        self.assertIsNone(self.dispatcher._function_metadata_exception)
 
     @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
     @patch.object(Dispatcher, 'index_functions')
@@ -818,8 +819,8 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.loop.run_until_complete(
             self.dispatcher._handle__worker_init_request(request))
 
-        self.assertIsNone(self.dispatcher.function_metadata_result)
-        self.assertIsNotNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNone(self.dispatcher._function_metadata_result)
+        self.assertIsNotNone(self.dispatcher._function_metadata_exception)
 
     @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
     def test_functions_metadata_request_with_init_indexing_enabled(self):
@@ -846,8 +847,8 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
 
         self.assertEqual(metadata_response.function_metadata_response.result.status,
                          protos.StatusResult.Success)
-        self.assertIsNotNone(self.dispatcher.function_metadata_result)
-        self.assertIsNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNotNone(self.dispatcher._function_metadata_result)
+        self.assertIsNone(self.dispatcher._function_metadata_exception)
 
     @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'false'})
     def test_functions_metadata_request_with_init_indexing_disabled(self):
@@ -868,16 +869,16 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
             self.dispatcher._handle__worker_init_request(init_request))
         self.assertEqual(init_response.worker_init_response.result.status,
                          protos.StatusResult.Success)
-        self.assertIsNone(self.dispatcher.function_metadata_result)
-        self.assertIsNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNone(self.dispatcher._function_metadata_result)
+        self.assertIsNone(self.dispatcher._function_metadata_exception)
 
         metadata_response = self.loop.run_until_complete(
             self.dispatcher._handle__functions_metadata_request(metadata_request))
 
         self.assertEqual(metadata_response.function_metadata_response.result.status,
                          protos.StatusResult.Success)
-        self.assertIsNotNone(self.dispatcher.function_metadata_result)
-        self.assertIsNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNotNone(self.dispatcher._function_metadata_result)
+        self.assertIsNone(self.dispatcher._function_metadata_exception)
 
     @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
     @patch.object(Dispatcher, 'index_functions')
@@ -903,8 +904,8 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.loop.run_until_complete(
             self.dispatcher._handle__worker_init_request(request))
 
-        self.assertIsNone(self.dispatcher.function_metadata_result)
-        self.assertIsNotNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNone(self.dispatcher._function_metadata_result)
+        self.assertIsNotNone(self.dispatcher._function_metadata_exception)
 
         metadata_response = self.loop.run_until_complete(
             self.dispatcher._handle__functions_metadata_request(
@@ -926,18 +927,18 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.loop.run_until_complete(
             self.dispatcher._handle__worker_init_request(init_request))
 
-        self.assertIsNone(self.dispatcher.function_metadata_result)
+        self.assertIsNone(self.dispatcher._function_metadata_result)
 
         load_request = protos.StreamingMessage(
             function_load_request=protos.FunctionLoadRequest(
                 function_id="http_trigger",
                 metadata=protos.RpcFunctionMetadata(
                     directory=str(FUNCTION_APP_DIRECTORY),
-                    properties={"worker_indexed": "True"}
+                    properties={METADATA_PROPERTIES_WORKER_INDEXED: "True"}
                 )))
 
         self.loop.run_until_complete(
             self.dispatcher._handle__function_load_request(load_request))
 
-        self.assertIsNotNone(self.dispatcher.function_metadata_result)
-        self.assertIsNone(self.dispatcher.function_metadata_exception)
+        self.assertIsNotNone(self.dispatcher._function_metadata_result)
+        self.assertIsNone(self.dispatcher._function_metadata_exception)

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -13,7 +13,7 @@ from azure_functions_worker.constants import (PYTHON_THREADPOOL_THREAD_COUNT,
                                               PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT,
                                               PYTHON_THREADPOOL_THREAD_COUNT_MAX_37,
                                               PYTHON_THREADPOOL_THREAD_COUNT_MIN,
-                                              ENABLE_INIT_INDEXING,
+                                              PYTHON_ENABLE_INIT_INDEXING,
                                               METADATA_PROPERTIES_WORKER_INDEXED)
 from azure_functions_worker.dispatcher import Dispatcher
 from azure_functions_worker.version import VERSION
@@ -691,7 +691,7 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
     async def test_dispatcher_indexing_in_init_request(self):
         """Test if azure functions is loaded during init
         """
-        env = {ENABLE_INIT_INDEXING: "1"}
+        env = {PYTHON_ENABLE_INIT_INDEXING: "1"}
         with patch.dict(os.environ, env):
             async with self._ctrl as host:
                 r = await host.init_worker()
@@ -772,7 +772,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'true'})
     def test_worker_init_request_with_indexing_enabled(self):
 
         request = protos.StreamingMessage(
@@ -788,7 +788,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNotNone(self.dispatcher._function_metadata_result)
         self.assertIsNone(self.dispatcher._function_metadata_exception)
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'false'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'false'})
     def test_worker_init_request_with_indexing_disabled(self):
         request = protos.StreamingMessage(
             worker_init_request=protos.WorkerInitRequest(
@@ -803,7 +803,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNone(self.dispatcher._function_metadata_result)
         self.assertIsNone(self.dispatcher._function_metadata_exception)
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'true'})
     @patch.object(Dispatcher, 'index_functions')
     def test_worker_init_request_with_indexing_exception(self,
                                                          mock_index_functions):
@@ -822,7 +822,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNone(self.dispatcher._function_metadata_result)
         self.assertIsNotNone(self.dispatcher._function_metadata_exception)
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'true'})
     def test_functions_metadata_request_with_init_indexing_enabled(self):
         init_request = protos.StreamingMessage(
             worker_init_request=protos.WorkerInitRequest(
@@ -850,7 +850,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNotNone(self.dispatcher._function_metadata_result)
         self.assertIsNone(self.dispatcher._function_metadata_exception)
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'false'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'false'})
     def test_functions_metadata_request_with_init_indexing_disabled(self):
         init_request = protos.StreamingMessage(
             worker_init_request=protos.WorkerInitRequest(
@@ -880,7 +880,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNotNone(self.dispatcher._function_metadata_result)
         self.assertIsNone(self.dispatcher._function_metadata_exception)
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'true'})
     @patch.object(Dispatcher, 'index_functions')
     def test_functions_metadata_request_with_indexing_exception(
             self,
@@ -915,7 +915,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
             metadata_response.function_metadata_response.result.status,
             protos.StatusResult.Failure)
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'false'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'false'})
     def test_dispatcher_indexing_in_load_request(self):
         init_request = protos.StreamingMessage(
             worker_init_request=protos.WorkerInitRequest(
@@ -943,7 +943,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNotNone(self.dispatcher._function_metadata_result)
         self.assertIsNone(self.dispatcher._function_metadata_exception)
 
-    @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'true'})
+    @patch.dict(os.environ, {PYTHON_ENABLE_INIT_INDEXING: 'true'})
     @patch.object(Dispatcher, 'index_functions')
     def test_dispatcher_indexing_in_load_request_with_exception(
             self,

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -14,7 +14,8 @@ from azure_functions_worker.constants import (PYTHON_THREADPOOL_THREAD_COUNT,
                                               PYTHON_THREADPOOL_THREAD_COUNT_MAX_37,
                                               PYTHON_THREADPOOL_THREAD_COUNT_MIN,
                                               PYTHON_ENABLE_INIT_INDEXING,
-                                              METADATA_PROPERTIES_WORKER_INDEXED)
+                                              METADATA_PROPERTIES_WORKER_INDEXED,
+                                              PYTHON_ENABLE_DEBUG_LOGGING)
 from azure_functions_worker.dispatcher import Dispatcher
 from azure_functions_worker.version import VERSION
 from tests.utils import testutils
@@ -691,7 +692,8 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
     async def test_dispatcher_indexing_in_init_request(self):
         """Test if azure functions is loaded during init
         """
-        env = {PYTHON_ENABLE_INIT_INDEXING: "1"}
+        env = {PYTHON_ENABLE_INIT_INDEXING: "1",
+               PYTHON_ENABLE_DEBUG_LOGGING: "1"}
         with patch.dict(os.environ, env):
             async with self._ctrl as host:
                 r = await host.init_worker()
@@ -704,7 +706,7 @@ class TestDispatcherInitRequest(testutils.AsyncTestCase):
 
                 self.assertEqual(
                     len([log for log in r.logs if log.message.startswith(
-                        "Received WorkerMetadataRequest from "
+                        "Received load metadata request from "
                         "worker_init_request"
                     )]),
                     1

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -9,9 +9,11 @@ from typing import Optional, Tuple
 from unittest.mock import patch
 
 from azure_functions_worker import protos
-from azure_functions_worker.constants import PYTHON_THREADPOOL_THREAD_COUNT, \
-    PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT, \
-    PYTHON_THREADPOOL_THREAD_COUNT_MAX_37, PYTHON_THREADPOOL_THREAD_COUNT_MIN, ENABLE_INIT_INDEXING
+from azure_functions_worker.constants import (PYTHON_THREADPOOL_THREAD_COUNT,
+                                              PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT,
+                                              PYTHON_THREADPOOL_THREAD_COUNT_MAX_37,
+                                              PYTHON_THREADPOOL_THREAD_COUNT_MIN,
+                                              ENABLE_INIT_INDEXING)
 from azure_functions_worker.version import VERSION
 from tests.utils import testutils
 from tests.utils.testutils import UNIT_TESTS_ROOT
@@ -841,7 +843,7 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNone(self.dispatcher.function_metadata_exception)
 
     @patch.dict(os.environ, {ENABLE_INIT_INDEXING: 'false'})
-    def test_functions_metadata_request_with_init_indexing_enabled(self):
+    def test_functions_metadata_request_with_init_indexing_disabled(self):
         init_request = protos.StreamingMessage(
             worker_init_request=protos.WorkerInitRequest(
                 host_version="2.3.4",
@@ -861,7 +863,6 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
                          protos.StatusResult.Success)
         self.assertIsNone(self.dispatcher.function_metadata_result)
         self.assertIsNone(self.dispatcher.function_metadata_exception)
-
 
         metadata_response = self.loop.run_until_complete(
             self.dispatcher._handle__functions_metadata_request(metadata_request))
@@ -915,12 +916,12 @@ class TestDispatcherIndexinginInit(unittest.TestCase):
         self.assertIsNone(self.dispatcher.function_metadata_result)
 
         load_request = protos.StreamingMessage(
-                function_load_request=protos.FunctionLoadRequest(
-                    function_id="http_trigger",
-                    metadata=protos.RpcFunctionMetadata(
-                        directory=str(FUNCTION_APP_DIRECTORY),
-                        properties={"worker_indexed": "True"}
-                    )))
+            function_load_request=protos.FunctionLoadRequest(
+                function_id="http_trigger",
+                metadata=protos.RpcFunctionMetadata(
+                    directory=str(FUNCTION_APP_DIRECTORY),
+                    properties={"worker_indexed": "True"}
+                )))
 
         self.loop.run_until_complete(
             self.dispatcher._handle__function_load_request(load_request))

--- a/tests/unittests/test_utilities.py
+++ b/tests/unittests/test_utilities.py
@@ -374,8 +374,7 @@ class TestUtilities(unittest.TestCase):
 
     def test_valid_script_file_name(self):
         file_name = 'test.py'
-        valid_name = common.validate_script_file_name(file_name)
-        self.assertTrue(valid_name)
+        common.validate_script_file_name(file_name)
 
     def test_invalid_script_file_name(self):
         file_name = 'test'


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Included in this PR:
- In the dispatcher, indexing is moved from metadata request to init request and env reload request and results are stored and returned in the metadata response
- Indexing in init is behind an flag: ENABLE_INIT_INDEXING
- Unit tests, e2e tests and consumption tests

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
