### PR TITLE
fix: allow returning none for generic bindings

### DIFF
--- a/azure_functions_worker/bindings/datumdef.py
+++ b/azure_functions_worker/bindings/datumdef.py
@@ -197,6 +197,8 @@ def datum_as_proto(datum: Datum) -> protos.TypedData:
             enable_content_negotiation=False,
             body=datum_as_proto(datum.value['body']),
         ))
+    elif datum.type is None:
+        return None
     else:
         raise NotImplementedError(
             'unexpected Datum type: {!r}'.format(datum.type)

--- a/azure_functions_worker/bindings/generic.py
+++ b/azure_functions_worker/bindings/generic.py
@@ -28,12 +28,17 @@ class GenericBinding:
 
         elif isinstance(obj, (bytes, bytearray)):
             return datumdef.Datum(type='bytes', value=bytes(obj))
-
+        elif obj is None:
+            return datumdef.Datum(type=None, value=obj)
         else:
             raise NotImplementedError
 
     @classmethod
     def decode(cls, data: datumdef.Datum, *, trigger_metadata) -> typing.Any:
+        # Enabling support for Dapr bindings
+        # https://github.com/Azure/azure-functions-python-worker/issues/1316
+        if data is None:
+            return None
         data_type = data.type
 
         if data_type == 'string':
@@ -42,6 +47,8 @@ class GenericBinding:
             result = data.value
         elif data_type == 'json':
             result = data.value
+        elif data_type is None:
+            result = None
         else:
             raise ValueError(
                 f'unexpected type of data received for the "generic" binding '

--- a/azure_functions_worker/bindings/meta.py
+++ b/azure_functions_worker/bindings/meta.py
@@ -178,9 +178,8 @@ def to_outgoing_param_binding(binding: str, obj: typing.Any, *,
             rpc_shared_memory=shared_mem_value)
     else:
         # If not, send it as part of the response message over RPC
+        # rpc_val can be None here as we now support a None return type
         rpc_val = datumdef.datum_as_proto(datum)
-        if rpc_val is None:
-            raise TypeError('Cannot convert datum to rpc_val')
         return protos.ParameterBinding(
             name=out_name,
             data=rpc_val)

--- a/tests/endtoend/generic_functions/generic_functions_stein/function_app.py
+++ b/tests/endtoend/generic_functions/generic_functions_stein/function_app.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 import azure.functions as func
+import logging
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
@@ -29,3 +30,16 @@ def return_processed_last(req: func.HttpRequest, testEntity):
     table_name="EventHubBatchTest")
 def return_not_processed_last(req: func.HttpRequest, testEntities):
     return func.HttpResponse(status_code=200)
+
+
+@app.function_name(name="mytimer")
+@app.schedule(schedule="*/1 * * * * *", arg_name="mytimer",
+              run_on_startup=False,
+              use_monitor=False)
+@app.generic_input_binding(
+    arg_name="testEntity",
+    type="table",
+    connection="AzureWebJobsStorage",
+    table_name="EventHubBatchTest")
+def mytimer(mytimer: func.TimerRequest, testEntity) -> None:
+    logging.info("This timer trigger function executed successfully")

--- a/tests/endtoend/generic_functions/return_none/function.json
+++ b/tests/endtoend/generic_functions/return_none/function.json
@@ -1,0 +1,21 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+      {
+        "name": "mytimer",
+        "type": "timerTrigger",
+        "direction": "in",
+        "schedule": "*/1 * * * * *",
+        "runOnStartup": false
+      },
+      {
+        "direction": "in",
+        "type": "table",
+        "name": "testEntity",
+        "partitionKey": "test",
+        "rowKey": "WillBePopulatedWithGuid",
+        "tableName": "BindingTestTable",
+        "connection": "AzureWebJobsStorage"
+      }
+    ]
+  }

--- a/tests/endtoend/generic_functions/return_none/main.py
+++ b/tests/endtoend/generic_functions/return_none/main.py
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import logging
+
+import azure.functions as func
+
+
+def main(mytimer: func.TimerRequest, testEntity) -> None:
+    logging.info("This timer trigger function executed successfully")

--- a/tests/endtoend/test_generic_functions.py
+++ b/tests/endtoend/test_generic_functions.py
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 from unittest import skipIf
 
+import time
+import typing
+
 from azure_functions_worker.utils.common import is_envvar_true
 from tests.utils import testutils
 from tests.utils.constants import DEDICATED_DOCKER_TEST, CONSUMPTION_DOCKER_TEST
@@ -40,6 +43,17 @@ class TestGenericFunctions(testutils.WebHostTestCase):
 
         r = self.webhost.request('GET', 'return_not_processed_last')
         self.assertEqual(r.status_code, 200)
+
+    def test_return_none(self):
+        time.sleep(1)
+        # Checking webhost status.
+        r = self.webhost.request('GET', '', no_prefix=True,
+                                 timeout=5)
+        self.assertTrue(r.ok)
+
+    def check_log_timer(self, host_out: typing.List[str]):
+        self.assertEqual(host_out.count("This timer trigger function executed "
+                                        "successfully"), 1)
 
 
 @skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)

--- a/tests/unittests/generic_functions/foobar_nil_data/function.json
+++ b/tests/unittests/generic_functions/foobar_nil_data/function.json
@@ -1,0 +1,10 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+      {
+        "type": "generic",
+        "name": "input",
+        "direction": "in"
+      }
+    ]
+  }

--- a/tests/unittests/generic_functions/foobar_nil_data/main.py
+++ b/tests/unittests/generic_functions/foobar_nil_data/main.py
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import logging
+
+
+def main(input) -> None:
+    logging.info("Hello World")

--- a/tests/unittests/test_mock_generic_functions.py
+++ b/tests/unittests/test_mock_generic_functions.py
@@ -144,6 +144,8 @@ class TestGenericFunctions(testutils.AsyncTestCase):
             # implicitly
             self.assertEqual(r.response.result.status,
                              protos.StatusResult.Success)
+            self.assertEqual(r.response.return_value,
+                             protos.TypedData(bytes=b'\x00\x01'))
 
     async def test_mock_generic_should_support_without_datatype(self):
         async with testutils.start_mockhost(
@@ -195,3 +197,28 @@ class TestGenericFunctions(testutils.AsyncTestCase):
             # For the Durable Functions durableClient case
             self.assertEqual(r.response.result.status,
                              protos.StatusResult.Failure)
+
+    async def test_mock_generic_as_nil_data(self):
+        async with testutils.start_mockhost(
+                script_root=self.generic_funcs_dir) as host:
+
+            await host.init_worker("4.17.1")
+            func_id, r = await host.load_function('foobar_nil_data')
+
+            self.assertEqual(r.response.function_id, func_id)
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+
+            _, r = await host.invoke_function(
+                'foobar_nil_data', [
+                    protos.ParameterBinding(
+                        name='input',
+                        data=protos.TypedData()
+                    )
+                ]
+            )
+            self.assertEqual(r.response.result.status,
+                             protos.StatusResult.Success)
+            self.assertEqual(
+                r.response.return_value,
+                protos.TypedData())


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Currently, when a function is triggered, the worker expects a request body with the trigger. However, in the case of generic binding types like the Dapr Cron binding trigger, no data is sent with the trigger request. This causes the worker to crash with an exception `AttributeError: 'NoneType' object has no attribute 'type'`. This fix enables triggers to execute successfully even if the trigger calls the app without any request body.

As per [1391](https://github.com/Azure/azure-functions-python-worker/pull/1391), implicit output is enabled for generic types. Therefore, function apps with generic bindings that are also returning None will face an error `TypeError: unable to encode outgoing TypedData: unsupported type "<class 'azure_functions_worker.bindings.generic.GenericBinding'>" for Python type "NoneType"`. This changes the worker to allow this scenario.


<!-- please list issues, if any -->
Fixes https://github.com/Azure/azure-functions-python-worker/issues/1316
Fixes https://github.com/Azure/azure-functions-python-worker/issues/1479

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
