### PR TITLE
fix: publish worker nuget package

### DIFF
--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -194,6 +194,9 @@ jobs:
           publishVstsFeed: "e6a70c92-4128-439f-8012-382fe78d6396/f37f760c-aebd-443e-9714-ce725cd427df"
           nuGetFeedType: "internal"
           allowPackageConflicts: true
+        - output: pipelineArtifact
+          targetPath: $(Build.SourcesDirectory)
+          artifactName: "PythonWorker"
   steps:
   - bash: |
       echo "Releasing from $BUILD_SOURCEBRANCHNAME"

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -187,7 +187,7 @@ jobs:
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:
         - output: pipelineArtifact
-          targetPath: $(Build.SourcesDirectory)
+          targetPath: $(Build.ArtifactStagingDirectory)
           artifactName: "PythonWorker"
   steps:
   - bash: |

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -186,14 +186,6 @@ jobs:
   templateContext:
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:
-        - output: nuget
-          condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dev'), eq(variables['UPLOADPACKAGETOPRERELEASEFEED'], true))
-          useDotNetTask: false
-          packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
-          packageParentPath: "$(Build.ArtifactStagingDirectory)"
-          publishVstsFeed: "e6a70c92-4128-439f-8012-382fe78d6396/f37f760c-aebd-443e-9714-ce725cd427df"
-          nuGetFeedType: "internal"
-          allowPackageConflicts: true
         - output: pipelineArtifact
           targetPath: $(Build.SourcesDirectory)
           artifactName: "PythonWorker"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Publish worker nuget package in the build-artifacts pipeline.

Removes packaging and publishing to pre-release feed as it is not being used currently and takes a long time. Will add back and investigate parallelizing this task at a later time.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
