### PR TITLE
fix: changed target path for builds

### DIFF
--- a/.artifactignore
+++ b/.artifactignore
@@ -1,0 +1,7 @@
+_manifest\**
+bcde-output\**
+Experiment_PipReport_**
+GovCompDisc_Log_**
+GovCompDisc_Manifest_**
+GovCompDisc_Metadata_**
+ScanTelemetry_**

--- a/eng/templates/official/jobs/build-artifacts.yml
+++ b/eng/templates/official/jobs/build-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
       - output: pipelineArtifact
-        targetPath: $(Build.SourcesDirectory)
+        targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: "$(pythonVersion)_WINDOWS_X64"
   steps:
   - template: ../../../../pack/templates/win_env_gen.yml
@@ -66,7 +66,7 @@ jobs:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
       - output: pipelineArtifact
-        targetPath: $(Build.SourcesDirectory)
+        targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: "$(pythonVersion)_WINDOWS_X86"
   steps:
   - template: ../../../../pack/templates/win_env_gen.yml
@@ -104,7 +104,7 @@ jobs:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
       - output: pipelineArtifact
-        targetPath: $(Build.SourcesDirectory)
+        targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: "$(pythonVersion)_LINUX_X64"
   steps:
   - template: ../../../../pack/templates/nix_env_gen.yml
@@ -141,7 +141,7 @@ jobs:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
       - output: pipelineArtifact
-        targetPath: $(Build.SourcesDirectory)
+        targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: "$(pythonVersion)_OSX_X64"
   steps:
   - template: ../../../../pack/templates/nix_env_gen.yml
@@ -172,7 +172,7 @@ jobs:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
       - output: pipelineArtifact
-        targetPath: $(Build.SourcesDirectory)
+        targetPath: $(Build.ArtifactStagingDirectory)
         artifactName: "$(pythonVersion)_OSX_ARM4"
   steps:
   - template: ../../../../pack/templates/macos_64_env_gen.yml

--- a/pack/scripts/mac_arm64_deps.sh
+++ b/pack/scripts/mac_arm64_deps.sh
@@ -7,3 +7,4 @@ python -m pip install --upgrade pip
 python -m pip install .
 
 python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
+cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"

--- a/pack/scripts/nix_deps.sh
+++ b/pack/scripts/nix_deps.sh
@@ -7,3 +7,4 @@ python -m pip install --upgrade pip
 python -m pip install .
 
 python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
+cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"

--- a/pack/scripts/win_deps.ps1
+++ b/pack/scripts/win_deps.ps1
@@ -7,3 +7,4 @@ python -m pip install .
 $depsPath = Join-Path -Path $env:BUILD_SOURCESDIRECTORY -ChildPath "deps"
 
 python -m pip install . azure-functions --no-compile --target $depsPath.ToString()
+Copy-Item -Path ".artifactignore" -Destination $depsPath.ToString()

--- a/pack/templates/macos_64_env_gen.yml
+++ b/pack/templates/macos_64_env_gen.yml
@@ -23,11 +23,11 @@ steps:
     sourceFolder: '$(Build.SourcesDirectory)/deps'
     contents: |
       **
-      !grpc_tools/**/*
-      !grpcio_tools*/*
-      !build/*
-      !docs/*
-      !pack/*
-      !python/*
-      !tests/*
+      !grpc_tools\**\*
+      !grpcio_tools*\*
+      !build\**
+      !docs\**
+      !pack\**
+      !python\**
+      !tests\**
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/macos_64_env_gen.yml
+++ b/pack/templates/macos_64_env_gen.yml
@@ -23,11 +23,11 @@ steps:
     sourceFolder: '$(Build.SourcesDirectory)/deps'
     contents: |
       **
-      !grpc_tools\**\*
-      !grpcio_tools*\*
-      !build\**
-      !docs\**
-      !pack\**
-      !python\**
-      !tests\**
+      !grpc_tools/**/*
+      !grpcio_tools*/*
+      !build/**
+      !docs/**
+      !pack/**
+      !python/**
+      !tests/**
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/macos_64_env_gen.yml
+++ b/pack/templates/macos_64_env_gen.yml
@@ -25,4 +25,16 @@ steps:
       **
       !grpc_tools/**/*
       !grpcio_tools*/*
+      !_manifest/*
+      !bcde_output/*
+      !build/*
+      !docs/*
+      !pack/*
+      !python/*
+      !tests/*
+      !Experiment_PipReport_*
+      !GovCompDisc_Log_*
+      !GovCompDisc_Manifest_*
+      !GovCompDisc_Metadata_*
+      !ScanTelemetry_*
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/macos_64_env_gen.yml
+++ b/pack/templates/macos_64_env_gen.yml
@@ -25,16 +25,9 @@ steps:
       **
       !grpc_tools/**/*
       !grpcio_tools*/*
-      !_manifest/*
-      !bcde_output/*
       !build/*
       !docs/*
       !pack/*
       !python/*
       !tests/*
-      !Experiment_PipReport_*
-      !GovCompDisc_Log_*
-      !GovCompDisc_Manifest_*
-      !GovCompDisc_Metadata_*
-      !ScanTelemetry_*
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/nix_env_gen.yml
+++ b/pack/templates/nix_env_gen.yml
@@ -23,11 +23,11 @@ steps:
     sourceFolder: '$(Build.SourcesDirectory)/deps'
     contents: |
       **
-      !grpc_tools/**/*
-      !grpcio_tools*/*
-      !build/*
-      !docs/*
-      !pack/*
-      !python/*
-      !tests/*
+      !grpc_tools\**\*
+      !grpcio_tools*\*
+      !build\**
+      !docs\**
+      !pack\**
+      !python\**
+      !tests\**
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/nix_env_gen.yml
+++ b/pack/templates/nix_env_gen.yml
@@ -23,11 +23,11 @@ steps:
     sourceFolder: '$(Build.SourcesDirectory)/deps'
     contents: |
       **
-      !grpc_tools\**\*
-      !grpcio_tools*\*
-      !build\**
-      !docs\**
-      !pack\**
-      !python\**
-      !tests\**
+      !grpc_tools/**/*
+      !grpcio_tools*/*
+      !build/**
+      !docs/**
+      !pack/**
+      !python/**
+      !tests/**
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/nix_env_gen.yml
+++ b/pack/templates/nix_env_gen.yml
@@ -25,4 +25,16 @@ steps:
       **
       !grpc_tools/**/*
       !grpcio_tools*/*
+      !_manifest/*
+      !bcde_output/*
+      !build/*
+      !docs/*
+      !pack/*
+      !python/*
+      !tests/*
+      !Experiment_PipReport_*
+      !GovCompDisc_Log_*
+      !GovCompDisc_Manifest_*
+      !GovCompDisc_Metadata_*
+      !ScanTelemetry_*
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/nix_env_gen.yml
+++ b/pack/templates/nix_env_gen.yml
@@ -25,16 +25,9 @@ steps:
       **
       !grpc_tools/**/*
       !grpcio_tools*/*
-      !_manifest/*
-      !bcde_output/*
       !build/*
       !docs/*
       !pack/*
       !python/*
       !tests/*
-      !Experiment_PipReport_*
-      !GovCompDisc_Log_*
-      !GovCompDisc_Manifest_*
-      !GovCompDisc_Metadata_*
-      !ScanTelemetry_*
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/win_env_gen.yml
+++ b/pack/templates/win_env_gen.yml
@@ -25,16 +25,9 @@ steps:
       **
       !grpc_tools\**\*
       !grpcio_tools*\*
-      !_manifest/*
-      !bcde_output/*
       !build/*
       !docs/*
       !pack/*
       !python/*
       !tests/*
-      !Experiment_PipReport_*
-      !GovCompDisc_Log_*
-      !GovCompDisc_Manifest_*
-      !GovCompDisc_Metadata_*
-      !ScanTelemetry_*
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/win_env_gen.yml
+++ b/pack/templates/win_env_gen.yml
@@ -25,4 +25,16 @@ steps:
       **
       !grpc_tools\**\*
       !grpcio_tools*\*
+      !_manifest/*
+      !bcde_output/*
+      !build/*
+      !docs/*
+      !pack/*
+      !python/*
+      !tests/*
+      !Experiment_PipReport_*
+      !GovCompDisc_Log_*
+      !GovCompDisc_Manifest_*
+      !GovCompDisc_Metadata_*
+      !ScanTelemetry_*
     targetFolder: '$(Build.ArtifactStagingDirectory)'

--- a/pack/templates/win_env_gen.yml
+++ b/pack/templates/win_env_gen.yml
@@ -25,9 +25,9 @@ steps:
       **
       !grpc_tools\**\*
       !grpcio_tools*\*
-      !build/*
-      !docs/*
-      !pack/*
-      !python/*
-      !tests/*
+      !build\**
+      !docs\**
+      !pack\**
+      !python\**
+      !tests\**
     targetFolder: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

- Changed target path to ArtifactsStagingDirectory for builds. This addresses an issue where the dependency files weren't being output to the correct location.
- Adds an .artifactignore file to ignore 1ES PT generated files when publishing artifacts.
- Updates the ignored directories when installing dependencies.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
