### PR TITLE
fix: use invoke to build protos

### DIFF
--- a/pack/scripts/mac_arm64_deps.sh
+++ b/pack/scripts/mac_arm64_deps.sh
@@ -9,6 +9,8 @@ python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
 
 cd tests
 python -m invoke -c test_setup build-protos
-python -m invoke -c test_setup build-protos --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
 
+cd ..
 cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"
+cp azure_functions_worker/protos/FunctionRpc_pb2_grpc.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"
+cp azure_functions_worker/protos/FunctionRpc_pb2.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"

--- a/pack/scripts/mac_arm64_deps.sh
+++ b/pack/scripts/mac_arm64_deps.sh
@@ -7,6 +7,7 @@ python -m pip install --upgrade pip
 python -m pip install .
 python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
 
+python -m pip install invoke
 cd tests
 python -m invoke -c test_setup build-protos
 

--- a/pack/scripts/mac_arm64_deps.sh
+++ b/pack/scripts/mac_arm64_deps.sh
@@ -5,6 +5,10 @@ source .env/bin/activate
 python -m pip install --upgrade pip
 
 python -m pip install .
-
 python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
+
+cd tests
+python -m invoke -c test_setup build-protos
+python -m invoke -c test_setup build-protos --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
+
 cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"

--- a/pack/scripts/nix_deps.sh
+++ b/pack/scripts/nix_deps.sh
@@ -9,6 +9,8 @@ python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
 
 cd tests
 python -m invoke -c test_setup build-protos
-python -m invoke -c test_setup build-protos --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
 
+cd ..
 cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"
+cp azure_functions_worker/protos/FunctionRpc_pb2_grpc.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"
+cp azure_functions_worker/protos/FunctionRpc_pb2.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"

--- a/pack/scripts/nix_deps.sh
+++ b/pack/scripts/nix_deps.sh
@@ -7,6 +7,7 @@ python -m pip install --upgrade pip
 python -m pip install .
 python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
 
+python -m pip install invoke
 cd tests
 python -m invoke -c test_setup build-protos
 

--- a/pack/scripts/nix_deps.sh
+++ b/pack/scripts/nix_deps.sh
@@ -5,6 +5,10 @@ source .env/bin/activate
 python -m pip install --upgrade pip
 
 python -m pip install .
-
 python -m pip install . --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
+
+cd tests
+python -m invoke -c test_setup build-protos
+python -m invoke -c test_setup build-protos --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
+
 cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"

--- a/pack/scripts/win_deps.ps1
+++ b/pack/scripts/win_deps.ps1
@@ -7,4 +7,9 @@ python -m pip install .
 $depsPath = Join-Path -Path $env:BUILD_SOURCESDIRECTORY -ChildPath "deps"
 
 python -m pip install . azure-functions --no-compile --target $depsPath.ToString()
+
+cd tests
+python -m invoke -c test_setup build-protos
+python -m invoke -c test_setup build-protos --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
+
 Copy-Item -Path ".artifactignore" -Destination $depsPath.ToString()

--- a/pack/scripts/win_deps.ps1
+++ b/pack/scripts/win_deps.ps1
@@ -14,5 +14,5 @@ python -m invoke -c test_setup build-protos
 
 cd ..
 Copy-Item -Path ".artifactignore" -Destination $depsPath.ToString()
-Copy-Item -Path "azure_functions_worker/protos/FunctionRpc_pb2_grpc.py" -Destination $depsPath.ToString()
+Copy-Item -Path "azure_functions_worker/protos/FunctionRpc_pb2_grpc.py" -Destination $protosPath.ToString()
 Copy-Item -Path "azure_functions_worker/protos/FunctionRpc_pb2.py" -Destination $protosPath.ToString()

--- a/pack/scripts/win_deps.ps1
+++ b/pack/scripts/win_deps.ps1
@@ -9,6 +9,7 @@ $protosPath = Join-Path -Path $depsPath -ChildPath "azure_functions_worker/proto
 
 python -m pip install . azure-functions --no-compile --target $depsPath.ToString()
 
+python -m pip install invoke
 cd tests
 python -m invoke -c test_setup build-protos
 

--- a/pack/scripts/win_deps.ps1
+++ b/pack/scripts/win_deps.ps1
@@ -5,11 +5,14 @@ python -m pip install --upgrade pip
 python -m pip install .
 
 $depsPath = Join-Path -Path $env:BUILD_SOURCESDIRECTORY -ChildPath "deps"
+$protosPath = Join-Path -Path $depsPath -ChildPath "azure_functions_worker/protos"
 
 python -m pip install . azure-functions --no-compile --target $depsPath.ToString()
 
 cd tests
 python -m invoke -c test_setup build-protos
-python -m invoke -c test_setup build-protos --no-compile --target "$BUILD_SOURCESDIRECTORY/deps"
 
+cd ..
 Copy-Item -Path ".artifactignore" -Destination $depsPath.ToString()
+Copy-Item -Path "azure_functions_worker/protos/FunctionRpc_pb2_grpc.py" -Destination $depsPath.ToString()
+Copy-Item -Path "azure_functions_worker/protos/FunctionRpc_pb2.py" -Destination $protosPath.ToString()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,7 @@ dependencies = [
      "grpcio-tools~=1.59.0; python_version >= '3.8'",
      "grpcio~=1.43.0; python_version == '3.7'",
      "grpcio~=1.59.0; python_version >= '3.8'",
-     "azurefunctions-extensions-base; python_version >= '3.8'",
-     "invoke"
+     "azurefunctions-extensions-base; python_version >= '3.8'"
 ]
 
 [project.urls]
@@ -69,7 +68,8 @@ dev = [
     "opencv-python",
     "pandas",
     "numpy",
-    "pre-commit"
+    "pre-commit",
+    "invoke"
 ]
 test-http-v2 = [
     "azurefunctions-extensions-http-fastapi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
      "grpcio-tools~=1.59.0; python_version >= '3.8'",
      "grpcio~=1.43.0; python_version == '3.7'",
      "grpcio~=1.59.0; python_version >= '3.8'",
-     "azurefunctions-extensions-base; python_version >= '3.8'"
+     "azurefunctions-extensions-base; python_version >= '3.8'",
+     "invoke"
 ]
 
 [project.urls]
@@ -68,8 +69,7 @@ dev = [
     "opencv-python",
     "pandas",
     "numpy",
-    "pre-commit",
-    "invoke"
+    "pre-commit"
 ]
 test-http-v2 = [
     "azurefunctions-extensions-http-fastapi",


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixes issue where protos files are not generated when using pyproject.toml.

In dependency installation script, we now:
- install invoke
- use invoke to generate the protos files
- copy the required files to the correct location

TODO: better fix

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
