### PR TITLE
fix: copy entire protos folder to /deps

### DIFF
--- a/pack/scripts/mac_arm64_deps.sh
+++ b/pack/scripts/mac_arm64_deps.sh
@@ -13,5 +13,4 @@ python -m invoke -c test_setup build-protos
 
 cd ..
 cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"
-cp azure_functions_worker/protos/FunctionRpc_pb2_grpc.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"
-cp azure_functions_worker/protos/FunctionRpc_pb2.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"
+cp -r azure_functions_worker/protos "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker"

--- a/pack/scripts/nix_deps.sh
+++ b/pack/scripts/nix_deps.sh
@@ -13,5 +13,4 @@ python -m invoke -c test_setup build-protos
 
 cd ..
 cp .artifactignore "$BUILD_SOURCESDIRECTORY/deps"
-cp azure_functions_worker/protos/FunctionRpc_pb2_grpc.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"
-cp azure_functions_worker/protos/FunctionRpc_pb2.py "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker/protos"
+cp -r azure_functions_worker/protos "$BUILD_SOURCESDIRECTORY/deps/azure_functions_worker"

--- a/pack/scripts/win_deps.ps1
+++ b/pack/scripts/win_deps.ps1
@@ -15,5 +15,4 @@ python -m invoke -c test_setup build-protos
 
 cd ..
 Copy-Item -Path ".artifactignore" -Destination $depsPath.ToString()
-Copy-Item -Path "azure_functions_worker/protos/FunctionRpc_pb2_grpc.py" -Destination $protosPath.ToString()
-Copy-Item -Path "azure_functions_worker/protos/FunctionRpc_pb2.py" -Destination $protosPath.ToString()
+Copy-Item -Path "azure_functions_worker/protos/*" -Destination $protosPath.ToString() -Recurse -Force


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Addresses issue where certain protos files aren't being copied over when built. Now copies entire protos file that was built from build-protos command to deps.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
