### PR TITLE
test: removed skipping for docker tests

### DIFF
--- a/tests/endtoend/test_eventhub_batch_functions.py
+++ b/tests/endtoend/test_eventhub_batch_functions.py
@@ -12,11 +12,6 @@ from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
 from azure_functions_worker.utils.common import is_envvar_true
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Table functions which are used in the bindings in these tests"
-        " has a bug with the table extension 1.0.0. "
-        "https://github.com/Azure/azure-sdk-for-net/issues/33902.")
 class TestEventHubFunctions(testutils.WebHostTestCase):
     """Test EventHub Trigger and Output Bindings (cardinality: many).
 
@@ -135,11 +130,6 @@ class TestEventHubFunctions(testutils.WebHostTestCase):
             self.assertIsNotNone(sys_props['Offset'])
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Table functions which are used in the bindings has a bug with the"
-        " table extension 1.0.0. "
-        "https://github.com/Azure/azure-sdk-for-net/issues/33902.")
 class TestEventHubBatchFunctionsStein(testutils.WebHostTestCase):
 
     @classmethod

--- a/tests/endtoend/test_eventhub_batch_functions.py
+++ b/tests/endtoend/test_eventhub_batch_functions.py
@@ -3,13 +3,9 @@
 import json
 import time
 from datetime import datetime
-from unittest import skipIf
 
 from dateutil import parser
 from tests.utils import testutils
-from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
-
-from azure_functions_worker.utils.common import is_envvar_true
 
 
 class TestEventHubFunctions(testutils.WebHostTestCase):

--- a/tests/endtoend/test_generic_functions.py
+++ b/tests/endtoend/test_generic_functions.py
@@ -2,12 +2,8 @@
 # Licensed under the MIT License.
 import time
 import typing
-from unittest import skipIf
 
 from tests.utils import testutils
-from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
-
-from azure_functions_worker.utils.common import is_envvar_true
 
 
 class TestGenericFunctions(testutils.WebHostTestCase):

--- a/tests/endtoend/test_generic_functions.py
+++ b/tests/endtoend/test_generic_functions.py
@@ -10,11 +10,6 @@ from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
 from azure_functions_worker.utils.common import is_envvar_true
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Table functions which are used in the bindings in these tests"
-        " has a bug with the table extension 1.0.0. "
-        "https://github.com/Azure/azure-sdk-for-net/issues/33902.")
 class TestGenericFunctions(testutils.WebHostTestCase):
     """Test Generic Functions with implicit output enabled
 
@@ -73,10 +68,6 @@ class TestGenericFunctions(testutils.WebHostTestCase):
         self.assertFalse(errors_found)
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Table functions has a bug with the table extension 1.0.0."
-        "https://github.com/Azure/azure-sdk-for-net/issues/33902.")
 class TestGenericFunctionsStein(TestGenericFunctions):
 
     @classmethod

--- a/tests/endtoend/test_servicebus_functions.py
+++ b/tests/endtoend/test_servicebus_functions.py
@@ -10,9 +10,6 @@ from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
 from azure_functions_worker.utils.common import is_envvar_true
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Skipping SB tests till docker image is updated with host 4.33")
 class TestServiceBusFunctions(testutils.WebHostTestCase):
 
     @classmethod

--- a/tests/endtoend/test_servicebus_functions.py
+++ b/tests/endtoend/test_servicebus_functions.py
@@ -2,12 +2,8 @@
 # Licensed under the MIT License.
 import json
 import time
-from unittest import skipIf
 
 from tests.utils import testutils
-from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
-
-from azure_functions_worker.utils.common import is_envvar_true
 
 
 class TestServiceBusFunctions(testutils.WebHostTestCase):

--- a/tests/endtoend/test_table_functions.py
+++ b/tests/endtoend/test_table_functions.py
@@ -11,10 +11,6 @@ from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
 from azure_functions_worker.utils.common import is_envvar_true
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Table functions has a bug with the table extension 1.0.0."
-        "https://github.com/Azure/azure-sdk-for-net/issues/33902.")
 class TestTableFunctions(testutils.WebHostTestCase):
 
     @classmethod
@@ -50,10 +46,6 @@ class TestTableFunctions(testutils.WebHostTestCase):
         self.assertTrue(row_key_present)
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Table functions has a bug with the table extension 1.0.0."
-        "https://github.com/Azure/azure-sdk-for-net/issues/33902.")
 class TestTableFunctionsStein(testutils.WebHostTestCase):
 
     @classmethod
@@ -76,10 +68,6 @@ class TestTableFunctionsStein(testutils.WebHostTestCase):
         self.assertTrue(row_key_present)
 
 
-@skipIf(is_envvar_true(DEDICATED_DOCKER_TEST)
-        or is_envvar_true(CONSUMPTION_DOCKER_TEST),
-        "Table functions has a bug with the table extension 1.0.0."
-        "https://github.com/Azure/azure-sdk-for-net/issues/33902.")
 class TestTableFunctionsGeneric(TestTableFunctionsStein):
 
     @classmethod

--- a/tests/endtoend/test_table_functions.py
+++ b/tests/endtoend/test_table_functions.py
@@ -3,12 +3,8 @@
 import json
 import pathlib
 import time
-from unittest import skipIf
 
 from tests.utils import testutils
-from tests.utils.constants import CONSUMPTION_DOCKER_TEST, DEDICATED_DOCKER_TEST
-
-from azure_functions_worker.utils.common import is_envvar_true
 
 
 class TestTableFunctions(testutils.WebHostTestCase):

--- a/tests/endtoend/test_worker_process_count_functions.py
+++ b/tests/endtoend/test_worker_process_count_functions.py
@@ -38,7 +38,7 @@ class TestWorkerProcessCount(testutils.WebHostTestCase):
     def get_environment_variables(cls):
         return cls.env_variables
 
-    @testutils.retryable_test(4, 5)
+    @testutils.retryable_test(5, 5)
     def test_http_func_with_worker_process_count_2(self):
         response = [None, None]
 

--- a/tests/endtoend/test_worker_process_count_functions.py
+++ b/tests/endtoend/test_worker_process_count_functions.py
@@ -38,7 +38,7 @@ class TestWorkerProcessCount(testutils.WebHostTestCase):
     def get_environment_variables(cls):
         return cls.env_variables
 
-    @testutils.retryable_test(5, 5)
+    @testutils.retryable_test(4, 5)
     def test_http_func_with_worker_process_count_2(self):
         response = [None, None]
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
There are multiple tests skipped unnecessarily when running docker tests.
- EventHub Batch: these no longer use table output bindings and use blob output instead
- Generic & table: these are using table extension version 1.2.1 now, which doesn't have the bug
- ServiceBus: the docker image has been updated with host 4.33

[Docker consumption test run](https://dev.azure.com/azfunc/internal/_build/results?buildId=178571&view=results) (internal only)
[Docker dedicated test run](https://dev.azure.com/azfunc/internal/_build/results?buildId=178572&view=results) (internal only)
There are no failures for any of these tests.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
