### PR TITLE
fix: Fixed default threadpool count for pyver> 3.9

### DIFF
--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -960,7 +960,7 @@ class Dispatcher(metaclass=DispatcherMeta):
 
         # Starting Python 3.9, worker won't be putting a limit on the
         # max_workers count in the created threadpool.
-        default_value = None if sys.version_info.minor == 9 \
+        default_value = None if sys.version_info.minor >= 9 \
             else f'{PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT}'
 
         max_workers = get_app_setting(setting=PYTHON_THREADPOOL_THREAD_COUNT,

--- a/azure_functions_worker/dispatcher.py
+++ b/azure_functions_worker/dispatcher.py
@@ -24,6 +24,7 @@ from . import bindings, constants, functions, loader, protos
 from .bindings.shared_memory_data_transfer import SharedMemoryManager
 from .constants import (
     APPLICATIONINSIGHTS_CONNECTION_STRING,
+    HTTP_URI,
     METADATA_PROPERTIES_WORKER_INDEXED,
     PYTHON_AZURE_MONITOR_LOGGER_NAME,
     PYTHON_AZURE_MONITOR_LOGGER_NAME_DEFAULT,
@@ -39,8 +40,7 @@ from .constants import (
     PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT,
     PYTHON_THREADPOOL_THREAD_COUNT_MAX_37,
     PYTHON_THREADPOOL_THREAD_COUNT_MIN,
-    REQUIRES_ROUTE_PARAMETERS,
-    HTTP_URI
+    REQUIRES_ROUTE_PARAMETERS
 )
 from .extension import ExtensionManager
 from .http_v2 import (

--- a/tests/unittests/test_dispatcher.py
+++ b/tests/unittests/test_dispatcher.py
@@ -14,13 +14,16 @@ from tests.utils.testutils import UNIT_TESTS_ROOT
 
 from azure_functions_worker import protos
 from azure_functions_worker.constants import (
+    HTTP_URI,
     METADATA_PROPERTIES_WORKER_INDEXED,
     PYTHON_ENABLE_DEBUG_LOGGING,
     PYTHON_ENABLE_INIT_INDEXING,
     PYTHON_THREADPOOL_THREAD_COUNT,
     PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT,
+    PYTHON_THREADPOOL_THREAD_COUNT_MAX,
     PYTHON_THREADPOOL_THREAD_COUNT_MAX_37,
-    PYTHON_THREADPOOL_THREAD_COUNT_MIN, HTTP_URI, REQUIRES_ROUTE_PARAMETERS,
+    PYTHON_THREADPOOL_THREAD_COUNT_MIN,
+    REQUIRES_ROUTE_PARAMETERS
 )
 from azure_functions_worker.dispatcher import Dispatcher, ContextEnabledTask
 from azure_functions_worker.version import VERSION
@@ -47,13 +50,15 @@ class TestThreadPoolSettingsPython37(testutils.AsyncTestCase):
     NEW_TYPING = sys.version_info[:3] >= (3, 7, 0)  # PEP 560
     """
 
-    def setUp(self, version=SysVersionInfo(3, 7, 0, 'final', 0)):
+    def setUp(self,
+              version: Optional[any] = SysVersionInfo(3, 7, 0, 'final', 0),
+              default_workers: Optional[int] = PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT,
+              max_workers: Optional[int] = PYTHON_THREADPOOL_THREAD_COUNT_MAX_37):
         self._ctrl = testutils.start_mockhost(
             script_root=DISPATCHER_FUNCTIONS_DIR)
-        self._default_workers: Optional[
-            int] = PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT
+        self._default_workers: int = default_workers
         self._over_max_workers: int = 10000
-        self._allowed_max_workers: int = PYTHON_THREADPOOL_THREAD_COUNT_MAX_37
+        self._allowed_max_workers: int = max_workers
         self._pre_env = dict(os.environ)
         self.mock_version_info = patch(
             'azure_functions_worker.dispatcher.sys.version_info',
@@ -63,7 +68,6 @@ class TestThreadPoolSettingsPython37(testutils.AsyncTestCase):
     def tearDown(self):
         os.environ.clear()
         os.environ.update(self._pre_env)
-        self.mock_version_info.stop()
 
     async def test_dispatcher_initialize_worker(self):
         """Test if the dispatcher can be initialized worker successfully
@@ -514,13 +518,14 @@ class TestThreadPoolSettingsPython37(testutils.AsyncTestCase):
 
 
 @unittest.skipIf(sys.version_info.minor != 8,
-                 "Run the tests only for Python 3.8. In other platforms, "
-                 "as the default passed is None, the cpu_count determines the "
-                 "number of max_workers and we cannot mock the os.cpu_count() "
-                 "in the concurrent.futures.ThreadPoolExecutor")
+                 "Run the tests only for Python 3.8.")
 class TestThreadPoolSettingsPython38(TestThreadPoolSettingsPython37):
-    def setUp(self, version=SysVersionInfo(3, 8, 0, 'final', 0)):
-        super(TestThreadPoolSettingsPython38, self).setUp(version)
+    def setUp(self, version=None, default_workers=None, max_workers=None):
+        version = sys.version_info
+        super(TestThreadPoolSettingsPython38, self).setUp(
+            version,
+            PYTHON_THREADPOOL_THREAD_COUNT_DEFAULT,
+            PYTHON_THREADPOOL_THREAD_COUNT_MAX)
         self._allowed_max_workers: int = self._over_max_workers
 
     def tearDown(self):
@@ -545,50 +550,43 @@ class TestThreadPoolSettingsPython38(TestThreadPoolSettingsPython37):
                     self._default_workers)
 
 
-@unittest.skipIf(sys.version_info.minor != 9,
-                 "Run the tests only for Python 3.9. In other platforms, "
-                 "as the default passed is None, the cpu_count determines the "
-                 "number of max_workers and we cannot mock the os.cpu_count() "
-                 "in the concurrent.futures.ThreadPoolExecutor")
-class TestThreadPoolSettingsPython39(TestThreadPoolSettingsPython38):
-    def setUp(self, version=SysVersionInfo(3, 9, 0, 'final', 0)):
-        super(TestThreadPoolSettingsPython39, self).setUp(version)
-
-        self.mock_os_cpu = patch(
-            'os.cpu_count', return_value=2)
-        # 6 - based on 2 cores - min(32, (os.cpu_count() or 1) + 4) - 2 + 4
-        self._default_workers: Optional[int] = 6
-        self.mock_os_cpu.start()
+@unittest.skipIf(sys.version_info.minor < 9,
+                 "Run the tests only for Python 3.9+.")
+class TestThreadPoolSettingsPython39(TestThreadPoolSettingsPython37):
+    """
+    For 3.9 and above, there is no limit on the max_workers count in the
+    created threadpool. The default value is set to None in the worker.
+    Therefore, the default thread count will be set by the Python
+    ThreadPoolExecutor, which does so by the formula
+    min(32, (os.cpu_count() or 1) + 4).
+    """
+    def setUp(self, version=None, default_workers=None, max_workers=None):
+        version = sys.version_info
+        default_workers = min(32, (os.cpu_count() or 1) + 4)
+        super(TestThreadPoolSettingsPython39, self).setUp(
+            version, default_workers, PYTHON_THREADPOOL_THREAD_COUNT_MAX)
+        self._allowed_max_workers: int = self._over_max_workers
 
     def tearDown(self):
-        self.mock_os_cpu.stop()
         super(TestThreadPoolSettingsPython39, self).tearDown()
 
+    async def test_dispatcher_sync_threadpool_in_placeholder_above_max(self):
+        """Test if the sync threadpool will use any value and there isn't any
+        artificial max value set.
+        """
+        with patch('azure_functions_worker.dispatcher.logger'):
+            async with self._ctrl as host:
+                await self._check_if_function_is_ok(host)
 
-@unittest.skipIf(sys.version_info.minor != 10,
-                 "Run the tests only for Python 3.10. In other platforms, "
-                 "as the default passed is None, the cpu_count determines the "
-                 "number of max_workers and we cannot mock the os.cpu_count() "
-                 "in the concurrent.futures.ThreadPoolExecutor")
-class TestThreadPoolSettingsPython310(TestThreadPoolSettingsPython39):
-    def setUp(self, version=SysVersionInfo(3, 10, 0, 'final', 0)):
-        super(TestThreadPoolSettingsPython310, self).setUp(version)
-
-    def tearDown(self):
-        super(TestThreadPoolSettingsPython310, self).tearDown()
-
-
-@unittest.skipIf(sys.version_info.minor != 11,
-                 "Run the tests only for Python 3.11. In other platforms, "
-                 "as the default passed is None, the cpu_count determines the "
-                 "number of max_workers and we cannot mock the os.cpu_count() "
-                 "in the concurrent.futures.ThreadPoolExecutor")
-class TestThreadPoolSettingsPython311(TestThreadPoolSettingsPython310):
-    def setUp(self, version=SysVersionInfo(3, 11, 0, 'final', 0)):
-        super(TestThreadPoolSettingsPython311, self).setUp(version)
-
-    def tearDown(self):
-        super(TestThreadPoolSettingsPython310, self).tearDown()
+                # Reload environment variable on specialization
+                await host.reload_environment(environment={
+                    PYTHON_THREADPOOL_THREAD_COUNT: f'{self._over_max_workers}'
+                })
+                await self._assert_workers_threadpool(self._ctrl, host,
+                                                      self._allowed_max_workers)
+                self.assertNotEqual(
+                    self._ctrl._worker.get_sync_tp_workers_set(),
+                    self._default_workers)
 
 
 class TestDispatcherStein(testutils.AsyncTestCase):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
From python 3.9 onwards, the threadpool count is not set, worker won't be putting a limit on the max_workers count in the created threadpool.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
