### PR TITLE
fix: reformat excludePathPatterns

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -30,6 +30,8 @@ resources:
 variables:
   - template: /eng/templates/utils/variables.yml@self
   - template: /eng/templates/utils/official-variables.yml@self
+  - name: codeql.excludePathPatterns
+    value: deps/,build/
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
@@ -39,9 +41,6 @@ extends:
       image: 1es-windows-2022
       os: windows
     sdl:
-      codeql:
-        # Exclude dependencies from CodeQL analysis
-        excludePathPatterns: '/deps,/build'
       codeSignValidation:
         enabled: true
         break: true

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -28,6 +28,12 @@ resources:
 
 variables:
   - template: /eng/templates/utils/variables.yml@self
+  - name: codeql.excludePathPatterns
+    value: deps/,build/
+  - name: codeql.compiled.enabled
+    value: true
+  - name: codeql.runSourceLanguagesInSourceAnalysis
+    value: true
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
@@ -36,13 +42,6 @@ extends:
       name: 1es-pool-azfunc-public
       image: 1es-windows-2022
       os: windows
-    sdl:
-      codeql:
-         compiled:
-           enabled: true # still only runs for default branch
-         runSourceLanguagesInSourceAnalysis: true
-         # Exclude dependencies from CodeQL analysis
-         excludePathPatterns: '/deps,/build'
     settings:
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
     stages:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Fixes formatting for CodeQL.excludePathPatterns.

Paths to be excluded are deps/ and build/, which contain third party dependency code.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
