### PR TITLE
build: update azurefunctions-extensions-http-fastapi version to 1.0.0b2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "cryptography"
 ]
 test-http-v2 = [
-    "azurefunctions-extensions-http-fastapi==1.0.0b1",
+    "azurefunctions-extensions-http-fastapi==1.0.0b2",
     "ujson",
     "orjson"
 ]


### PR DESCRIPTION
Python Extension [azurefunctions-extensions-http-fastapi] Version [1.0.0b2](https://github.com/Azure/azure-functions-python-extensions/releases/tag/azurefunctions-extensions-http-fastapi/1.0.0b2)