### PR TITLE
build: update azurefunctions-extensions-http-fastapi version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dev = [
     "cryptography"
 ]
 test-http-v2 = [
-    "azurefunctions-extensions-http-fastapi==1.0.0b2",
+    "azurefunctions-extensions-http-fastapi==1.0.0",
     "ujson",
     "orjson"
 ]


### PR DESCRIPTION
Python Extension [azurefunctions-extensions-http-fastapi] Version [1.0.0](https://github.com/Azure/azure-functions-python-extensions/releases/tag/azurefunctions-extensions-http-fastapi/1.0.0)