### PR TITLE
fix: remove deferred bindings cache

### DIFF
--- a/azure_functions_worker/bindings/meta.py
+++ b/azure_functions_worker/bindings/meta.py
@@ -22,7 +22,6 @@ PB_TYPE_RPC_SHARED_MEMORY = 'rpc_shared_memory'
 
 BINDING_REGISTRY = None
 DEFERRED_BINDING_REGISTRY = None
-deferred_bindings_cache = {}
 
 
 def _check_http_input_type_annotation(bind_name: str, pytype: type,
@@ -285,48 +284,8 @@ def deferred_bindings_decode(binding: typing.Any,
                              datum: typing.Any,
                              metadata: typing.Any,
                              function_name: str):
-    """
-    This cache holds deferred binding types (ie. BlobClient, ContainerClient)
-    That have already been created, so that the worker can reuse the
-    Previously created type without creating a new one.
 
-    For async types, the function_name is needed as a key to differentiate.
-    This prevents a known SDK issue where reusing a client across functions
-    can lose the session context and cause an error.
-
-    The cache key is based on: param name, type, resource, function_name
-
-    If cache is empty or key doesn't exist, deferred_binding_type is None
-    """
-    global deferred_bindings_cache
-
-    # Only applies to Event Hub and Service Bus - cannot cache
-    # These types will always produce different content and are not clients
-    if (datum.type == "collection_model_binding_data"
-            or datum.value.source == "AzureEventHubsEventData"
-            or datum.value.source == "AzureServiceBusReceivedMessage"):
-        return binding.decode(datum,
-                              trigger_metadata=metadata,
-                              pytype=pytype)
-
-    if deferred_bindings_cache.get((pb.name,
-                                    pytype,
-                                    datum.value.content,
-                                    function_name), None) is not None:
-        return deferred_bindings_cache.get((pb.name,
-                                            pytype,
-                                            datum.value.content,
-                                            function_name))
-    else:
-        deferred_binding_type = binding.decode(datum,
-                                               trigger_metadata=metadata,
-                                               pytype=pytype)
-
-        deferred_bindings_cache[(pb.name,
-                                 pytype,
-                                 datum.value.content,
-                                 function_name)] = deferred_binding_type
-        return deferred_binding_type
+    return binding.decode(datum, trigger_metadata=metadata, pytype=pytype)
 
 
 def check_deferred_bindings_enabled(param_anno: type,

--- a/tests/extension_tests/deferred_bindings_tests/deferred_bindings_blob_functions/function_app.py
+++ b/tests/extension_tests/deferred_bindings_tests/deferred_bindings_blob_functions/function_app.py
@@ -249,41 +249,6 @@ def put_blob_bytes(req: func.HttpRequest, file: func.Out[bytes]) -> str:
     return 'OK'
 
 
-@app.function_name(name="blob_cache")
-@app.blob_input(arg_name="cachedClient",
-                path="python-worker-tests/test-blobclient-triggered.txt",
-                connection="AzureWebJobsStorage")
-@app.route(route="blob_cache")
-def blob_cache(req: func.HttpRequest,
-               cachedClient: blob.BlobClient) -> str:
-    return func.HttpResponse(repr(cachedClient))
-
-
-@app.function_name(name="blob_cache2")
-@app.blob_input(arg_name="cachedClient",
-                path="python-worker-tests/test-blobclient-triggered.txt",
-                connection="AzureWebJobsStorage")
-@app.route(route="blob_cache2")
-def blob_cache2(req: func.HttpRequest,
-                cachedClient: blob.BlobClient) -> func.HttpResponse:
-    return func.HttpResponse(repr(cachedClient))
-
-
-@app.function_name(name="blob_cache3")
-@app.blob_input(arg_name="cachedClient",
-                path="python-worker-tests/test-blobclient-triggered.txt",
-                connection="AzureWebJobsStorage")
-@app.blob_input(arg_name="cachedClient2",
-                path="python-worker-tests/test-blobclient-triggered.txt",
-                connection="AzureWebJobsStorage")
-@app.route(route="blob_cache3")
-def blob_cache3(req: func.HttpRequest,
-                cachedClient: blob.BlobClient,
-                cachedClient2: blob.BlobClient) -> func.HttpResponse:
-    return func.HttpResponse("Client 1: " + repr(cachedClient)
-                             + " | Client 2: " + repr(cachedClient2))
-
-
 @app.function_name(name="invalid_connection_info")
 @app.blob_input(arg_name="client",
                 path="python-worker-tests/test-blobclient-triggered.txt",

--- a/tests/extension_tests/deferred_bindings_tests/test_deferred_bindings_blob_functions.py
+++ b/tests/extension_tests/deferred_bindings_tests/test_deferred_bindings_blob_functions.py
@@ -171,64 +171,6 @@ class TestDeferredBindingsBlobFunctions(testutils.WebHostTestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.text, 'test-data')
 
-    @unittest.skipIf(sys.version_info.minor >= 13, "For python 3.13+,"
-                     "the cache is maintained in the ext and TBD.")
-    def test_caching(self):
-        '''
-        The cache returns the same type based on resource and function name.
-        Two different functions with clients that access the same resource
-        will have two different clients. This tests that the same client
-        is returned for each invocation and that the clients are different
-        between the two functions.
-        '''
-
-        r = self.webhost.request('GET', 'blob_cache')
-        r2 = self.webhost.request('GET', 'blob_cache2')
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(r2.status_code, 200)
-        client = r.text
-        client2 = r2.text
-        self.assertNotEqual(client, client2)
-
-        r = self.webhost.request('GET', 'blob_cache')
-        r2 = self.webhost.request('GET', 'blob_cache2')
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(r2.status_code, 200)
-        self.assertEqual(r.text, client)
-        self.assertEqual(r2.text, client2)
-        self.assertNotEqual(r.text, r2.text)
-
-        r = self.webhost.request('GET', 'blob_cache')
-        r2 = self.webhost.request('GET', 'blob_cache2')
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(r2.status_code, 200)
-        self.assertEqual(r.text, client)
-        self.assertEqual(r2.text, client2)
-        self.assertNotEqual(r.text, r2.text)
-
-    @unittest.skipIf(sys.version_info.minor >= 13, "For python 3.13+,"
-                    "the cache is maintained in the ext and TBD.")
-    def test_caching_same_resource(self):
-        '''
-        The cache returns the same type based on param name.
-        One functions with two clients that access the same resource
-        will have two different clients. This tests that the same clients
-        are returned for each invocation and that the clients are different
-        between the two bindings.
-        '''
-
-        r = self.webhost.request('GET', 'blob_cache3')
-        self.assertEqual(r.status_code, 200)
-        clients = r.text.split(" | ")
-        self.assertNotEqual(clients[0], clients[1])
-
-        r2 = self.webhost.request('GET', 'blob_cache3')
-        self.assertEqual(r2.status_code, 200)
-        clients_second_call = r2.text.split(" | ")
-        self.assertEqual(clients[0], clients_second_call[0])
-        self.assertEqual(clients[1], clients_second_call[1])
-        self.assertNotEqual(clients_second_call[0], clients_second_call[1])
-
     def test_failed_client_creation(self):
         r = self.webhost.request('GET', 'invalid_connection_info')
         # Without the http_v2_enabled default definition, this request would time out.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Removes the deferred bindings cache from the worker. The cache will be implemented now on the respective extension side.

Part of https://github.com/orgs/Azure/projects/539/views/31?pane=issue&itemId=3049886802&issue=Azure%7Cazure-functions-pyfx-planning%7C739

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

### PR information
<!-- You can mark the following checkboxes as [x] to mark them during the PR creation itself. -->
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which has an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).
- [ ] If applicable, the PR references the bug/issue that it fixes in the description.
- [ ] New Unit tests were added for the changes made and CI is passing.

### Quality of Code and Contribution Guidelines
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-functions-python-worker/blob/master/.github/CONTRIBUTING.md).

<!-- Thanks for using the checklist -->
