### PR TITLE
fix: update worker.config for minimumSupportedRuntimeVersion

### DIFF
--- a/workers/python/prodV4/worker.config.json
+++ b/workers/python/prodV4/worker.config.json
@@ -4,6 +4,7 @@
         "defaultRuntimeVersion":"3.12",
         "supportedOperatingSystems":["LINUX", "OSX", "WINDOWS"],
         "supportedRuntimeVersions":["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+        "minimumSupportedRuntimeVersion":"3.9",
         "supportedArchitectures":["X64", "X86", "Arm64"],
         "extensions":[".py"],
         "defaultExecutablePath":"python",

--- a/workers/tests/endtoend/test_eol_log.py
+++ b/workers/tests/endtoend/test_eol_log.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+import re
+import sys
+import time
+import typing
+
+from tests.utils import testutils
+from unittest.case import skipIf
+
+REQUEST_TIMEOUT_SEC = 5
+
+
+@skipIf(sys.version_info.minor >= 9,
+        '3.9+ is supported.')
+class TestEOLFunctions(testutils.WebHostTestCase):
+
+    @classmethod
+    def get_script_dir(cls):
+        return testutils.E2E_TESTS_FOLDER / 'timer_functions'
+
+    def test_timer(self):
+        time.sleep(1)
+        # Checking webhost status.
+        r = self.webhost.request('GET', '', no_prefix=True,
+                                 timeout=REQUEST_TIMEOUT_SEC)
+        self.assertTrue(r.ok)
+
+    def check_log_timer(self, host_out: typing.List[str]):
+        self.assertEqual(host_out.count("This timer trigger function executed "
+                                        "successfully"), 1)
+        pattern = (
+            r"The configured runtime version '.*' "
+            r"for language '.*' "
+            r"is lower than the minimum supported version '.*'\. "
+            r"Please update to a supported version\. "
+            r"Visit aka\.ms/supported-language-versions for more information\."
+        )
+
+        found = any(re.search(pattern, log) for log in host_out)
+        self.assertTrue(found)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

In `worker.config`, a new property called `minimumSupportedRuntimeVersion` will be added. This will be the oldest supported version for each language. Any version older is EOL.

See corresponding Host PR: https://github.com/Azure/azure-functions-host/pull/11253

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] azure_functions_worker_v1 / azure_functions_worker_v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (azure_functions_worker_v1)?
   - [ ] V2 programming model (azure_functions_worker_v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
