### PR TITLE
build: allow for downloading artifact from partially successful pipelines

### DIFF
--- a/eng/templates/official/jobs/publish-library-release.yml
+++ b/eng/templates/official/jobs/publish-library-release.yml
@@ -60,6 +60,9 @@ jobs:
   - script: |
       echo "##vso[task.setvariable variable=BranchName]refs/heads/${{ parameters.BRANCH_NAME }}/$(NewLibraryVersion)"
     displayName: 'Set branch variable'
+  - powershell: |
+        Write-Host "BranchName: $(BranchName)"
+    displayName: 'Display BranchName variable'  
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Python V2 Library release-*/x.y.z Artifact'
     inputs:
@@ -69,7 +72,9 @@ jobs:
       specificBuildWithTriggering: true
       buildVersionToDownload: latestFromBranch
       branchName: '$(BranchName)'
-      targetPath: PythonRuntimeArtifact
+      allowPartiallySucceededBuilds: true
+      allowFailedBuilds: true
+      targetPath: '$(Pipeline.Workspace)/PythonWorkerArtifact'
   - task: UsePythonVersion@0
     displayName: 'Use Python 3.13'
     inputs:


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Currently, the library worker release pipeline requires all stages in the official build pipeline to pass in order to download & publish the artifact. In case of flaky tests or GitHub outages, this change allows for the artifact to be downloaded even if the pipeline as a whole fails. If the build itself fails, there will be no artifact to download, so this is not an unsafe change.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
