### PR TITLE
fix: Py3.13 grpc size limit fix

### DIFF
--- a/workers/proxy_worker/dispatcher.py
+++ b/workers/proxy_worker/dispatcher.py
@@ -247,9 +247,9 @@ class Dispatcher(metaclass=DispatcherMeta):
     def __poll_grpc(self):
         options = []
         if self._grpc_max_msg_len:
-            options.append(('grpc_local.max_receive_message_length',
+            options.append(('grpc.max_receive_message_length',
                             self._grpc_max_msg_len))
-            options.append(('grpc_local.max_send_message_length',
+            options.append(('grpc.max_send_message_length',
                             self._grpc_max_msg_len))
 
         channel = grpc.insecure_channel(

--- a/workers/tests/emulator_tests/test_blob_functions.py
+++ b/workers/tests/emulator_tests/test_blob_functions.py
@@ -8,8 +8,6 @@ from tests.utils import testutils
 from unittest.case import skipIf
 
 
-@skipIf(sys.version_info.minor >= 13,
-        'Temporary skip for Python 3.13+')
 class TestBlobFunctions(testutils.WebHostTestCase):
 
     @classmethod
@@ -154,8 +152,6 @@ class TestBlobFunctions(testutils.WebHostTestCase):
                     raise
 
 
-@skipIf(sys.version_info.minor >= 13,
-        'Temporary skip for Python 3.13+')
 class TestBlobFunctionsStein(TestBlobFunctions):
 
     @classmethod
@@ -164,8 +160,6 @@ class TestBlobFunctionsStein(TestBlobFunctions):
             'blob_functions_stein'
 
 
-@skipIf(sys.version_info.minor >= 13,
-        'Temporary skip for Python 3.13+')
 class TestBlobFunctionsSteinGeneric(TestBlobFunctions):
 
     @classmethod

--- a/workers/tests/emulator_tests/test_blob_functions.py
+++ b/workers/tests/emulator_tests/test_blob_functions.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-import sys
 import time
 
 from requests import JSONDecodeError
 from tests.utils import testutils
-from unittest.case import skipIf
 
 
 class TestBlobFunctions(testutils.WebHostTestCase):


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

**Issue**: 
HTTP trigger functions with large payloads fail silently in Python 3.13 using the proxy worker. The invocation request never reaches the worker's handler method, preventing the function from executing.

**Root Cause:** 
The proxy worker uses incorrect gRPC channel option names (grpc_local.max_receive_message_length and grpc_local.max_send_message_length) instead of the correct names ([grpc.max_receive_message_length](vscode-file://vscode-app/c:/Users/gaaguiar/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [grpc.max_send_message_length](vscode-file://vscode-app/c:/Users/gaaguiar/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)). This causes gRPC to ignore the configuration and fall back to the default 4MB message size limit, silently dropping messages that exceed this threshold.
<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
