### PR TITLE
fix: Py3.13+ logging issue with operation_Name

### DIFF
--- a/runtimes/v1/azure_functions_runtime_v1/__init__.py
+++ b/runtimes/v1/azure_functions_runtime_v1/__init__.py
@@ -11,6 +11,7 @@ from .utils.threadpool import (
     stop_threadpool_executor,
     get_threadpool_executor,
 )
+from .utils.executor import invocation_id_cv
 
 __all__ = ('worker_init_request',
            'functions_metadata_request',
@@ -19,4 +20,5 @@ __all__ = ('worker_init_request',
            'function_load_request',
            'start_threadpool_executor',
            'stop_threadpool_executor',
-           'get_threadpool_executor')
+           'get_threadpool_executor',
+           'invocation_id_cv')

--- a/runtimes/v1/azure_functions_runtime_v1/utils/executor.py
+++ b/runtimes/v1/azure_functions_runtime_v1/utils/executor.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import asyncio
+import contextvars
 import functools
 
 from typing import Any
@@ -21,14 +22,19 @@ def execute_sync(function, args) -> Any:
     return function(**args)
 
 
+invocation_id_cv = contextvars.ContextVar('invocation_id', default=None)
+
+
 def run_sync_func(invocation_id, context, func, params):
     # This helper exists because we need to access the current
     # invocation_id from ThreadPoolExecutor's threads.
     context.thread_local_storage.invocation_id = invocation_id
+    token = invocation_id_cv.set(invocation_id)
     try:
         if otel_manager.get_azure_monitor_available():
             configure_opentelemetry(context)
         result = functools.partial(execute_sync, func)
         return result(params)
     finally:
+        invocation_id_cv.reset(token)
         context.thread_local_storage.invocation_id = None

--- a/runtimes/v2/azure_functions_runtime/__init__.py
+++ b/runtimes/v2/azure_functions_runtime/__init__.py
@@ -10,6 +10,7 @@ from .utils.threadpool import (
     stop_threadpool_executor,
     get_threadpool_executor,
 )
+from .utils.executor import invocation_id_cv
 
 __all__ = ('worker_init_request',
            'functions_metadata_request',
@@ -18,4 +19,5 @@ __all__ = ('worker_init_request',
            'function_load_request',
            'start_threadpool_executor',
            'stop_threadpool_executor',
-           'get_threadpool_executor')
+           'get_threadpool_executor',
+           'invocation_id_cv')

--- a/runtimes/v2/azure_functions_runtime/utils/executor.py
+++ b/runtimes/v2/azure_functions_runtime/utils/executor.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 import asyncio
+import contextvars
 import functools
 
 from typing import Any
@@ -20,10 +21,14 @@ def execute_sync(function, args) -> Any:
     return function(**args)
 
 
+invocation_id_cv = contextvars.ContextVar('invocation_id', default=None)
+
+
 def run_sync_func(invocation_id, context, func, params):
     # This helper exists because we need to access the current
     # invocation_id from ThreadPoolExecutor's threads.
     context.thread_local_storage.invocation_id = invocation_id
+    token = invocation_id_cv.set(invocation_id)
     try:
         if (otel_manager.get_azure_monitor_available()
                 or otel_manager.get_otel_libs_available()):
@@ -31,4 +36,5 @@ def run_sync_func(invocation_id, context, func, params):
         result = functools.partial(execute_sync, func)
         return result(params)
     finally:
+        invocation_id_cv.reset(token)
         context.thread_local_storage.invocation_id = None

--- a/workers/proxy_worker/dispatcher.py
+++ b/workers/proxy_worker/dispatcher.py
@@ -99,11 +99,6 @@ def get_global_current_invocation_id() -> Optional[str]:
 
 
 def get_current_invocation_id() -> Optional[Any]:
-    # Check global current invocation first (most up-to-date)
-    global_invocation_id = get_global_current_invocation_id()
-    if global_invocation_id is not None:
-        return global_invocation_id
-
     # Check asyncio task context
     try:
         loop = asyncio._get_running_loop()
@@ -124,6 +119,18 @@ def get_current_invocation_id() -> Optional[Any]:
     thread_invocation_id = get_thread_invocation_id(current_thread_id)
     if thread_invocation_id is not None:
         return thread_invocation_id
+
+    # Check contextvar from library worker
+    global _library_worker
+    if _library_worker:
+        try:
+            cv = getattr(_library_worker, 'invocation_id_cv', None)
+            if cv:
+                val = cv.get()
+                if val is not None:
+                    return val
+        except (AttributeError, LookupError):
+            pass
 
     return getattr(_invocation_id_local, 'invocation_id', None)
 

--- a/workers/proxy_worker/dispatcher.py
+++ b/workers/proxy_worker/dispatcher.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import grpc
+from packaging.version import Version
+
 from proxy_worker import protos
 from proxy_worker.logging import (
     CONSOLE_LOG_PREFIX,
@@ -32,7 +34,6 @@ from proxy_worker.utils.constants import (
     PYTHON_ENABLE_DEBUG_LOGGING,
 )
 from proxy_worker.version import VERSION
-
 from .utils.dependency import DependencyManager
 
 # Library worker import reloaded in init and reload request
@@ -99,6 +100,13 @@ def get_global_current_invocation_id() -> Optional[str]:
 
 
 def get_current_invocation_id() -> Optional[Any]:
+    global _library_worker
+    # Check global current invocation first (most up-to-date)
+    if _library_worker and Version(_library_worker.version.VERSION) < Version("1.1.0b4"):
+        global_invocation_id = get_global_current_invocation_id()
+        if global_invocation_id is not None:
+            return global_invocation_id
+
     # Check asyncio task context
     try:
         loop = asyncio._get_running_loop()
@@ -121,7 +129,6 @@ def get_current_invocation_id() -> Optional[Any]:
         return thread_invocation_id
 
     # Check contextvar from library worker
-    global _library_worker
     if _library_worker:
         try:
             cv = getattr(_library_worker, 'invocation_id_cv', None)

--- a/workers/proxy_worker/dispatcher.py
+++ b/workers/proxy_worker/dispatcher.py
@@ -102,7 +102,8 @@ def get_global_current_invocation_id() -> Optional[str]:
 def get_current_invocation_id() -> Optional[Any]:
     global _library_worker
     # Check global current invocation first (most up-to-date)
-    if _library_worker and Version(_library_worker.version.VERSION) < Version("1.1.0b4"):
+    if (_library_worker
+            and Version(_library_worker.version.VERSION) < Version("1.1.0b4")):
         global_invocation_id = get_global_current_invocation_id()
         if global_invocation_id is not None:
             return global_invocation_id

--- a/workers/tests/unittest_proxy/test_dispatcher.py
+++ b/workers/tests/unittest_proxy/test_dispatcher.py
@@ -460,8 +460,8 @@ class TestInvocationTracking(unittest.TestCase):
         # Test clear non-existent (should not raise)
         clear_thread_invocation_id(99999)
 
-    def test_get_current_invocation_id_priority_global(self):
-        """Test that global invocation ID has highest priority"""
+    def test_get_current_invocation_id_ignores_global_by_default(self):
+        """Test that global invocation ID is ignored by default"""
         global_id = "global-123"
         thread_id = threading.get_ident()
         thread_id_value = "thread-456"
@@ -470,9 +470,9 @@ class TestInvocationTracking(unittest.TestCase):
         set_current_invocation_id(global_id)
         set_thread_invocation_id(thread_id, thread_id_value)
 
-        # Global should take priority
+        # Thread should take priority (global is ignored)
         result = get_current_invocation_id()
-        self.assertEqual(result, global_id)
+        self.assertEqual(result, thread_id_value)
 
     def test_get_current_invocation_id_fallback_to_thread(self):
         """Test fallback to thread registry when global is None"""


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

In Python 3.13 Function Apps, logs and traces were intermittently showing incorrect operation_Name values. For example, logs generated by function1 were sometimes tagged with the operation name of function2

Root Cause:
The issue stemmed from a race condition in the proxy_worker

The proxy_worker used a global variable _current_invocation_id as a fallback to identify which function invocation a log message belonged to.
When multiple functions ran concurrently, this global variable was overwritten by the most recent request.
Synchronous functions (which run in a thread pool) were not correctly exposing their specific invocation ID to the logging handler.
Consequently, the logging handler fell back to the global variable, which often held the ID of a different concurrent request, leading to mismatched operation names in the logs.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
