### PR TITLE
fix: Update timezone in reload request

### DIFF
--- a/runtimes/v1/azure_functions_runtime_v1/handle_event.py
+++ b/runtimes/v1/azure_functions_runtime_v1/handle_event.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import sys
+import time
 import typing
 
 from .functions import FunctionInfo, Registry
@@ -274,6 +275,9 @@ async def function_environment_reload_request(request):
         env_vars = func_env_reload_request.environment_variables
         for var in env_vars:
             os.environ[var] = env_vars[var]
+
+        # Refresh timezone information after environment reload
+        time.tzset()
 
         if is_envvar_true(PYTHON_ENABLE_DEBUG_LOGGING):
             root_logger = logging.getLogger()

--- a/runtimes/v2/azure_functions_runtime/handle_event.py
+++ b/runtimes/v2/azure_functions_runtime/handle_event.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import sys
+import time
 
 from typing import List, MutableMapping, Optional
 
@@ -306,7 +307,6 @@ async def function_environment_reload_request(request):
                  "Version %s", VERSION)
     global _host, protos
     try:
-
         func_env_reload_request = \
             request.request.function_environment_reload_request
         directory = func_env_reload_request.function_app_directory
@@ -323,7 +323,8 @@ async def function_environment_reload_request(request):
         for var in env_vars:
             os.environ[var] = env_vars[var]
 
-        # TODO: Apply PYTHON_THREADPOOL_THREAD_COUNT
+        # Refresh timezone information after environment reload
+        time.tzset()
 
         if is_envvar_true(PYTHON_ENABLE_DEBUG_LOGGING):
             root_logger = logging.getLogger()

--- a/workers/azure_functions_worker/dispatcher.py
+++ b/workers/azure_functions_worker/dispatcher.py
@@ -13,6 +13,7 @@ import platform
 import queue
 import sys
 import threading
+import time
 from asyncio import BaseEventLoop
 from datetime import datetime
 from logging import LogRecord
@@ -774,6 +775,9 @@ class Dispatcher(metaclass=DispatcherMeta):
             env_vars = func_env_reload_request.environment_variables
             for var in env_vars:
                 os.environ[var] = env_vars[var]
+
+            # Refresh timezone information after environment reload
+            time.tzset()
 
             # Apply PYTHON_THREADPOOL_THREAD_COUNT
             self._stop_sync_call_tp()


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Setting timezone in the Reload request. 

Tested with updating `WEBSITE_TIME_ZONE` app setting to UTC, CST and PST shown below.
<img width="565" height="280" alt="image" src="https://github.com/user-attachments/assets/2d97a67b-7e21-4782-a615-2be96fb3967a" />

<!-- please list issues, if any -->
Fixes # https://github.com/Azure/azure-functions-pyfx-planning/issues/833

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
