### PR TITLE
build: remove extra nuget feeds

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,5 @@
   <packageSources>
     <clear />
     <add key="PythonWorker_Internal_PublicPackages" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/nuget/v3/index.json" />
-    <add key="PythonWorker_PublicPackages" value="https://azfunc.pkgs.visualstudio.com/public/_packaging/PythonWorker_PublicPackages/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fixes: https://dev.azure.com/azfunc/internal/_build/results?buildId=277749&view=logs&j=4f7f800a-3fec-5ec0-5370-d87b23c314e3&t=3bac7361-e92f-5b2c-57d0-802407379c78 (internal view only)

Doc reference: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/secure-supply-chain-analysis-task/cfs-detectors/nuget/cfs-nuget#multiple-feeds-declared

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
