### PR TITLE
build: update azurefunctions-extensions-base version to 1.3.0b1

### DIFF
--- a/workers/pyproject.toml
+++ b/workers/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
      "grpcio~=1.75.1; python_version == '3.14'",
      "uvloop~=0.21.0; python_version == '3.13' and sys_platform != 'win32'",
      "uvloop~=0.22.0; python_version == '3.14' and sys_platform != 'win32'",
-     "azurefunctions-extensions-base==1.2.0",
+     "azurefunctions-extensions-base==1.3.0b1",
      "azure-functions-runtime==1.1.1; python_version >= '3.13'",
      "azure-functions-runtime-v1==1.1.0; python_version >= '3.13'"
 ]


### PR DESCRIPTION
Python Extension [azurefunctions-extensions-base] Version [1.3.0b1](https://github.com/Azure/azure-functions-python-extensions/releases/tag/azurefunctions-extensions-base/1.3.0b1)