### PR TITLE
fix: move pip authenticate to first step for all pipelines

### DIFF
--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -4,15 +4,15 @@ parameters:
   grpcBuild: ''
 
 steps:
+- task: PipAuthenticate@1
+  displayName: 'Pip Authenticate'
+  inputs:
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
     allowUnstable: true
     addToPath: true
-- task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
-  inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - powershell: |
     # Parse the Python minor version
     $PY_VER = "$(pythonVersion)"

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -4,15 +4,15 @@ parameters:
   grpcBuild: ''
 
 steps:
+- task: PipAuthenticate@1
+  displayName: 'Pip Authenticate'
+  inputs:
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
     allowUnstable: true
     addToPath: true
-- task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
-  inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - powershell: |
     # Parse the Python minor version
     $PY_VER = "$(pythonVersion)"

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -4,15 +4,15 @@ parameters:
   grpcBuild: ''
 
 steps:
+- task: PipAuthenticate@1
+  displayName: 'Pip Authenticate'
+  inputs:
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
     allowUnstable: true
     addToPath: true
-- task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
-  inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - powershell: |
     # Parse the Python minor version
     $PY_VER = "$(pythonVersion)"

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -4,16 +4,16 @@ parameters:
   grpcBuild: ''
 
 steps:
+- task: PipAuthenticate@1
+  displayName: 'Pip Authenticate'
+  inputs:
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
     allowUnstable: true
     architecture: ${{ parameters.architecture }}
     addToPath: true
-- task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
-  inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 - powershell: |
     # Parse the Python minor version
     $PY_VER = "$(pythonVersion)"

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -25,13 +25,13 @@ jobs:
         Python314:
           PYTHON_VERSION: '3.14'
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - powershell: |
           $PY_VER = "$(PYTHON_VERSION)"
           Write-Host "Python version: $PY_VER"

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -27,6 +27,10 @@ jobs:
         Python314:
           PYTHON_VERSION: '3.14'
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: ${{ parameters.ArtifactFeed }}
       - bash: |
           echo "Disk space before cleanup:"
           df -h
@@ -68,10 +72,6 @@ jobs:
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
       - task: UseDotNet@2
         displayName: 'Install .NET 10'
         inputs:

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -19,13 +19,13 @@ jobs:
           PYTHON_VERSION: '3.13'
     
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - task: UseDotNet@2
         displayName: 'Install .NET 10'
         inputs:

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -27,6 +27,10 @@ jobs:
         Python314:
           PYTHON_VERSION: '3.14'
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: ${{ parameters.ArtifactFeed }}
       - bash: |
           echo "Disk space before cleanup:"
           df -h
@@ -71,10 +75,6 @@ jobs:
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
       - task: UseDotNet@2
         displayName: 'Install .NET 10'
         inputs:

--- a/eng/templates/official/jobs/build-library.yml
+++ b/eng/templates/official/jobs/build-library.yml
@@ -20,13 +20,13 @@ jobs:
           artifactName: "${{ parameters.ARTIFACT_NAME }}"
 
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: "3.13"
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'public/PythonWorker_PublicPackages'
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.13"
       - bash: |
           python --version
         displayName: 'Check python version'

--- a/eng/templates/official/jobs/ci-core-tools-tests.yml
+++ b/eng/templates/official/jobs/ci-core-tools-tests.yml
@@ -8,15 +8,15 @@ jobs:
       os: linux
     
     steps:
+    - task: PipAuthenticate@1
+      displayName: 'Pip Authenticate'
+      inputs:
+        artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
     - task: UsePythonVersion@0
       displayName: 'Install Python'
       inputs:
         versionSpec: "3.10"
         addToPath: true
-    - task: PipAuthenticate@1
-      displayName: 'Pip Authenticate'
-      inputs:
-        artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
     - task: UseDotNet@2
       displayName: 'Install DotNet 3'
       inputs:

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -11,13 +11,13 @@ jobs:
       os: linux
     
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(CUSTOM_PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(CUSTOM_PYTHON_VERSION)
       - bash: |
           chmod +x eng/scripts/install-dependencies.sh
 

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -38,13 +38,13 @@ jobs:
           EVENTGRID_CONNECTION: $(LinuxEventGridConnectionKeyString312)
 
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: $(PYTHON_VERSION)
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: $(PYTHON_VERSION)
       - bash: |
           chmod +x eng/scripts/install-dependencies.sh
 

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -50,6 +50,10 @@ jobs:
           EVENTGRID_URI: $(LinuxEventGridTopicUriString38)
           EVENTGRID_CONNECTION: $(LinuxEventGridConnectionKeyString38)
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
       - bash: |
           echo "Disk space before cleanup:"
           df -h
@@ -80,10 +84,6 @@ jobs:
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
       - task: UseDotNet@2
         displayName: 'Install .NET 10'
         inputs:

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -23,6 +23,10 @@ jobs:
          Python314:
            PYTHON_VERSION: '3.14'
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
       - bash: |
           echo "Disk space before cleanup:"
           df -h
@@ -44,10 +48,6 @@ jobs:
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
 
       - bash: |
           # Start Azurite storage emulator in the background

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -34,7 +34,7 @@ jobs:
 
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-24.04
       os: linux
 
     templateContext:

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -34,7 +34,7 @@ jobs:
 
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
 
     templateContext:
@@ -45,6 +45,10 @@ jobs:
           artifactName: ${{ parameters.artifactName }}
 
     steps:
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate'
+        inputs:
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
       - ${{ if ne(parameters.libraryVersion, '') }}:
         - checkout: none
         - bash: |
@@ -58,10 +62,6 @@ jobs:
       - bash: |
           python --version
         displayName: 'Check python version'
-      - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
-        inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
       - bash: |
           python -m pip install -U pip
           python -m pip install build

--- a/eng/templates/official/release/bump-version.yml
+++ b/eng/templates/official/release/bump-version.yml
@@ -46,7 +46,7 @@ jobs:
     displayName: 'Create Release Branch'
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
     steps:
     - powershell: |

--- a/eng/templates/official/release/bump-version.yml
+++ b/eng/templates/official/release/bump-version.yml
@@ -46,7 +46,7 @@ jobs:
     displayName: 'Create Release Branch'
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-24.04
       os: linux
     steps:
     - powershell: |

--- a/eng/templates/official/release/publish-release.yml
+++ b/eng/templates/official/release/publish-release.yml
@@ -186,7 +186,7 @@ jobs:
 
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04
       os: linux
 
     steps:

--- a/eng/templates/official/release/publish-release.yml
+++ b/eng/templates/official/release/publish-release.yml
@@ -236,7 +236,7 @@ jobs:
 
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04
       os: linux
 
     steps:

--- a/eng/templates/official/release/publish-release.yml
+++ b/eng/templates/official/release/publish-release.yml
@@ -186,7 +186,7 @@ jobs:
 
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-22.04
       os: linux
 
     steps:

--- a/eng/templates/shared/build-steps.yml
+++ b/eng/templates/shared/build-steps.yml
@@ -5,13 +5,13 @@ parameters:
   ArtifactFeed: ''
 
 steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: ${{ parameters.PYTHON_VERSION }}
   - task: PipAuthenticate@1
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: ${{ parameters.ArtifactFeed }}
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: ${{ parameters.PYTHON_VERSION }}
   - bash: |
       python --version
     displayName: 'Check python version'


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The `UsePythonVersion@0` task installs and upgrades `pip` - with the recent networking changes, this step will fail when the agent tries to install `pip` from pypi.org. This change moves the internal feed authentication task (`PipAuthenticate`) to always be the first step in all pipelines, so that whenever `pip` is installed, it's installed from the internal feed.

(previous) Example run: https://azfunc.visualstudio.com/internal/_build/results?buildId=292394&view=logs&j=444070dd-ff9b-522a-cc83-036544755457&t=339617d4-cdaa-5df9-bfd2-12ddd87b7576 - `UsePythonVersion@0` installs `pip` from pypi.org

(previous) Example failure: https://dev.azure.com/azfunc/internal/_build/results?buildId=291917&view=logs&j=b48799ae-91e6-58f0-f267-33373aeec3a4&t=42dbf9bc-daa4-5984-64ee-478aaf0ec50d&s=d4729883-749f-5ec1-ddc8-190d167414cc - `UsePythonVersion@0` task fails because network policies restrict pypi.org access when installing `pip`

(current) Example run: https://azfunc.visualstudio.com/internal/_build/results?buildId=292418&view=logs&jobId=35bc92f9-d4f9-539d-c334-5b5bd6a794ea&j=35bc92f9-d4f9-539d-c334-5b5bd6a794ea&t=19b8a4f6-5b46-5b60-2309-f02cc609a02d - installs `pip` through the internal feed.

Also includes minor pool updates for the release pipeline.

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
