### PR TITLE
build: migrate to CFS

### DIFF
--- a/eng/ci/emulator-tests.yml
+++ b/eng/ci/emulator-tests.yml
@@ -50,5 +50,5 @@ extends:
       - template: /eng/templates/jobs/ci-emulator-tests.yml@self
         parameters:
           PoolName: 1es-pool-azfunc
-          ArtifactFeed: 'internal/upstream'
-          NuGetServiceConnection: 'upstream'
+          
+          

--- a/eng/ci/emulator-tests.yml
+++ b/eng/ci/emulator-tests.yml
@@ -50,5 +50,5 @@ extends:
       - template: /eng/templates/jobs/ci-emulator-tests.yml@self
         parameters:
           PoolName: 1es-pool-azfunc
-          ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
-          NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
+          ArtifactFeed: 'internal/upstream'
+          NuGetServiceConnection: 'upstream'

--- a/eng/ci/emulator-tests.yml
+++ b/eng/ci/emulator-tests.yml
@@ -50,5 +50,3 @@ extends:
       - template: /eng/templates/jobs/ci-emulator-tests.yml@self
         parameters:
           PoolName: 1es-pool-azfunc
-          
-          

--- a/eng/ci/emulator-tests.yml
+++ b/eng/ci/emulator-tests.yml
@@ -50,5 +50,5 @@ extends:
       - template: /eng/templates/jobs/ci-emulator-tests.yml@self
         parameters:
           PoolName: 1es-pool-azfunc
-          ArtifactFeed: 'internal/upstream'
+          ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
           NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'

--- a/eng/ci/emulator-tests.yml
+++ b/eng/ci/emulator-tests.yml
@@ -50,5 +50,5 @@ extends:
       - template: /eng/templates/jobs/ci-emulator-tests.yml@self
         parameters:
           PoolName: 1es-pool-azfunc
-          ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
+          ArtifactFeed: 'internal/upstream'
           NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -63,14 +63,12 @@ extends:
           - template: /eng/templates/jobs/ci-emulator-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-    
       - stage: RunWorkerUnitTests
         dependsOn: BuildPythonWorker
         jobs:
           - template: /eng/templates/jobs/ci-unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-
       - stage: RunWorkerDockerDedicatedTests
         dependsOn: BuildPythonWorker
         jobs:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -63,16 +63,16 @@ extends:
           - template: /eng/templates/jobs/ci-emulator-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
-              NuGetServiceConnection: 'upstream'
+              
+              
       - stage: RunWorkerUnitTests
         dependsOn: BuildPythonWorker
         jobs:
           - template: /eng/templates/jobs/ci-unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
-              NuGetServiceConnection: 'upstream'
+              
+              
       - stage: RunWorkerDockerDedicatedTests
         dependsOn: BuildPythonWorker
         jobs:
@@ -99,8 +99,8 @@ extends:
               PROJECT_NAME: 'Python V2 Library'
               PROJECT_DIRECTORY: 'runtimes/v2'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
-              NuGetServiceConnection: 'upstream'
+              
+              
 
       # Python V1 Library Build and Test Stages
       - stage: BuildV1Library
@@ -119,5 +119,5 @@ extends:
               PROJECT_NAME: 'Python V1 Library'
               PROJECT_DIRECTORY: 'runtimes/v1'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
-              NuGetServiceConnection: 'upstream'
+              
+              

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -63,16 +63,14 @@ extends:
           - template: /eng/templates/jobs/ci-emulator-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              
-              
+    
       - stage: RunWorkerUnitTests
         dependsOn: BuildPythonWorker
         jobs:
           - template: /eng/templates/jobs/ci-unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              
-              
+
       - stage: RunWorkerDockerDedicatedTests
         dependsOn: BuildPythonWorker
         jobs:
@@ -99,8 +97,6 @@ extends:
               PROJECT_NAME: 'Python V2 Library'
               PROJECT_DIRECTORY: 'runtimes/v2'
               PoolName: 1es-pool-azfunc
-              
-              
 
       # Python V1 Library Build and Test Stages
       - stage: BuildV1Library
@@ -118,6 +114,4 @@ extends:
             parameters:
               PROJECT_NAME: 'Python V1 Library'
               PROJECT_DIRECTORY: 'runtimes/v1'
-              PoolName: 1es-pool-azfunc
-              
-              
+              PoolName: 1es-pool-azfunc 

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -63,16 +63,16 @@ extends:
           - template: /eng/templates/jobs/ci-emulator-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
-              NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
+              NuGetServiceConnection: 'upstream'
       - stage: RunWorkerUnitTests
         dependsOn: BuildPythonWorker
         jobs:
           - template: /eng/templates/jobs/ci-unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
-              NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
+              NuGetServiceConnection: 'upstream'
       - stage: RunWorkerDockerDedicatedTests
         dependsOn: BuildPythonWorker
         jobs:
@@ -99,8 +99,8 @@ extends:
               PROJECT_NAME: 'Python V2 Library'
               PROJECT_DIRECTORY: 'runtimes/v2'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
-              NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
+              NuGetServiceConnection: 'upstream'
 
       # Python V1 Library Build and Test Stages
       - stage: BuildV1Library
@@ -119,5 +119,5 @@ extends:
               PROJECT_NAME: 'Python V1 Library'
               PROJECT_DIRECTORY: 'runtimes/v1'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
-              NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
+              NuGetServiceConnection: 'upstream'

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -63,7 +63,7 @@ extends:
           - template: /eng/templates/jobs/ci-emulator-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
+              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
       - stage: RunWorkerUnitTests
         dependsOn: BuildPythonWorker
@@ -71,7 +71,7 @@ extends:
           - template: /eng/templates/jobs/ci-unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
+              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
       - stage: RunWorkerDockerDedicatedTests
         dependsOn: BuildPythonWorker
@@ -99,7 +99,7 @@ extends:
               PROJECT_NAME: 'Python V2 Library'
               PROJECT_DIRECTORY: 'runtimes/v2'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
+              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
 
       # Python V1 Library Build and Test Stages
@@ -119,5 +119,5 @@ extends:
               PROJECT_NAME: 'Python V1 Library'
               PROJECT_DIRECTORY: 'runtimes/v1'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/upstream'
+              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -63,7 +63,7 @@ extends:
           - template: /eng/templates/jobs/ci-emulator-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
       - stage: RunWorkerUnitTests
         dependsOn: BuildPythonWorker
@@ -71,7 +71,7 @@ extends:
           - template: /eng/templates/jobs/ci-unit-tests.yml@self
             parameters:
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
       - stage: RunWorkerDockerDedicatedTests
         dependsOn: BuildPythonWorker
@@ -99,7 +99,7 @@ extends:
               PROJECT_NAME: 'Python V2 Library'
               PROJECT_DIRECTORY: 'runtimes/v2'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
 
       # Python V1 Library Build and Test Stages
@@ -119,5 +119,5 @@ extends:
               PROJECT_NAME: 'Python V1 Library'
               PROJECT_DIRECTORY: 'runtimes/v1'
               PoolName: 1es-pool-azfunc
-              ArtifactFeed: 'internal/PythonWorker_Internal_PublicPackages'
+              ArtifactFeed: 'internal/upstream'
               NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -79,7 +79,7 @@ extends:
       - template: /eng/templates/jobs/ci-dependency-check.yml@self
         parameters:
           PoolName: 1es-pool-azfunc-public
-          ArtifactFeed: 'public/PythonWorker_PublicPackages'
+          ArtifactFeed: 'public/upstream-public'
     - stage: RunWorkerUnitTests
       dependsOn: BuildPythonWorker
       jobs:
@@ -87,7 +87,7 @@ extends:
           parameters:
             PROJECT_DIRECTORY: 'workers'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'
     - stage: RunWorkerEmulatorTests
       dependsOn: BuildPythonWorker
@@ -95,7 +95,7 @@ extends:
         - template: /eng/templates/jobs/ci-emulator-tests.yml@self
           parameters:
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'
     
     # Python V2 Library Build and Test Stages
@@ -115,7 +115,7 @@ extends:
             PROJECT_NAME: 'V2 Library'
             PROJECT_DIRECTORY: 'runtimes/v2'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'
 
     # Python V1 Library Build and Test Stages
@@ -135,5 +135,5 @@ extends:
             PROJECT_NAME: 'V1 Library'
             PROJECT_DIRECTORY: 'runtimes/v1'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -79,7 +79,7 @@ extends:
       - template: /eng/templates/jobs/ci-dependency-check.yml@self
         parameters:
           PoolName: 1es-pool-azfunc-public
-          ArtifactFeed: 'public/upstream-public'
+          
     - stage: RunWorkerUnitTests
       dependsOn: BuildPythonWorker
       jobs:
@@ -87,16 +87,16 @@ extends:
           parameters:
             PROJECT_DIRECTORY: 'workers'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
-            NuGetServiceConnection: 'upstream-public'
+            
+            
     - stage: RunWorkerEmulatorTests
       dependsOn: BuildPythonWorker
       jobs:
         - template: /eng/templates/jobs/ci-emulator-tests.yml@self
           parameters:
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
-            NuGetServiceConnection: 'upstream-public'
+            
+            
     
     # Python V2 Library Build and Test Stages
     - stage: BuildV2Library
@@ -115,8 +115,8 @@ extends:
             PROJECT_NAME: 'V2 Library'
             PROJECT_DIRECTORY: 'runtimes/v2'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
-            NuGetServiceConnection: 'upstream-public'
+            
+            
 
     # Python V1 Library Build and Test Stages
     - stage: BuildV1Library
@@ -135,5 +135,5 @@ extends:
             PROJECT_NAME: 'V1 Library'
             PROJECT_DIRECTORY: 'runtimes/v1'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
-            NuGetServiceConnection: 'upstream-public'
+            
+            

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -79,7 +79,7 @@ extends:
       - template: /eng/templates/jobs/ci-dependency-check.yml@self
         parameters:
           PoolName: 1es-pool-azfunc-public
-          ArtifactFeed: 'public/PythonWorker_PublicPackages'
+          ArtifactFeed: 'public/upstream-public'
     - stage: RunWorkerUnitTests
       dependsOn: BuildPythonWorker
       jobs:
@@ -87,16 +87,16 @@ extends:
           parameters:
             PROJECT_DIRECTORY: 'workers'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
-            NuGetServiceConnection: 'PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
+            NuGetServiceConnection: 'upstream-public'
     - stage: RunWorkerEmulatorTests
       dependsOn: BuildPythonWorker
       jobs:
         - template: /eng/templates/jobs/ci-emulator-tests.yml@self
           parameters:
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
-            NuGetServiceConnection: 'PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
+            NuGetServiceConnection: 'upstream-public'
     
     # Python V2 Library Build and Test Stages
     - stage: BuildV2Library
@@ -115,8 +115,8 @@ extends:
             PROJECT_NAME: 'V2 Library'
             PROJECT_DIRECTORY: 'runtimes/v2'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
-            NuGetServiceConnection: 'PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
+            NuGetServiceConnection: 'upstream-public'
 
     # Python V1 Library Build and Test Stages
     - stage: BuildV1Library
@@ -135,5 +135,5 @@ extends:
             PROJECT_NAME: 'V1 Library'
             PROJECT_DIRECTORY: 'runtimes/v1'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/PythonWorker_PublicPackages'
-            NuGetServiceConnection: 'PythonWorker_PublicPackages'
+            ArtifactFeed: 'public/upstream-public'
+            NuGetServiceConnection: 'upstream-public'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -79,7 +79,6 @@ extends:
       - template: /eng/templates/jobs/ci-dependency-check.yml@self
         parameters:
           PoolName: 1es-pool-azfunc-public
-          
     - stage: RunWorkerUnitTests
       dependsOn: BuildPythonWorker
       jobs:
@@ -87,14 +86,12 @@ extends:
           parameters:
             PROJECT_DIRECTORY: 'workers'
             PoolName: 1es-pool-azfunc-public
-
     - stage: RunWorkerEmulatorTests
       dependsOn: BuildPythonWorker
       jobs:
         - template: /eng/templates/jobs/ci-emulator-tests.yml@self
           parameters:
             PoolName: 1es-pool-azfunc-public
-
     # Python V2 Library Build and Test Stages
     - stage: BuildV2Library
       dependsOn: []

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -79,7 +79,7 @@ extends:
       - template: /eng/templates/jobs/ci-dependency-check.yml@self
         parameters:
           PoolName: 1es-pool-azfunc-public
-          ArtifactFeed: 'public/upstream-public'
+          ArtifactFeed: 'public/PythonWorker_PublicPackages'
     - stage: RunWorkerUnitTests
       dependsOn: BuildPythonWorker
       jobs:
@@ -87,7 +87,7 @@ extends:
           parameters:
             PROJECT_DIRECTORY: 'workers'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
+            ArtifactFeed: 'public/PythonWorker_PublicPackages'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'
     - stage: RunWorkerEmulatorTests
       dependsOn: BuildPythonWorker
@@ -95,7 +95,7 @@ extends:
         - template: /eng/templates/jobs/ci-emulator-tests.yml@self
           parameters:
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
+            ArtifactFeed: 'public/PythonWorker_PublicPackages'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'
     
     # Python V2 Library Build and Test Stages
@@ -115,7 +115,7 @@ extends:
             PROJECT_NAME: 'V2 Library'
             PROJECT_DIRECTORY: 'runtimes/v2'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
+            ArtifactFeed: 'public/PythonWorker_PublicPackages'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'
 
     # Python V1 Library Build and Test Stages
@@ -135,5 +135,5 @@ extends:
             PROJECT_NAME: 'V1 Library'
             PROJECT_DIRECTORY: 'runtimes/v1'
             PoolName: 1es-pool-azfunc-public
-            ArtifactFeed: 'public/upstream-public'
+            ArtifactFeed: 'public/PythonWorker_PublicPackages'
             NuGetServiceConnection: 'PythonWorker_PublicPackages'

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -87,17 +87,14 @@ extends:
           parameters:
             PROJECT_DIRECTORY: 'workers'
             PoolName: 1es-pool-azfunc-public
-            
-            
+
     - stage: RunWorkerEmulatorTests
       dependsOn: BuildPythonWorker
       jobs:
         - template: /eng/templates/jobs/ci-emulator-tests.yml@self
           parameters:
             PoolName: 1es-pool-azfunc-public
-            
-            
-    
+
     # Python V2 Library Build and Test Stages
     - stage: BuildV2Library
       dependsOn: []
@@ -115,8 +112,6 @@ extends:
             PROJECT_NAME: 'V2 Library'
             PROJECT_DIRECTORY: 'runtimes/v2'
             PoolName: 1es-pool-azfunc-public
-            
-            
 
     # Python V1 Library Build and Test Stages
     - stage: BuildV1Library
@@ -135,5 +130,3 @@ extends:
             PROJECT_NAME: 'V1 Library'
             PROJECT_DIRECTORY: 'runtimes/v1'
             PoolName: 1es-pool-azfunc-public
-            
-            

--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -8,6 +8,7 @@ steps:
   displayName: 'Pip Authenticate'
   inputs:
     artifactFeeds: 'internal/upstream'
+    onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -147,7 +148,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "✅ Found gRPC binary: $grpcMatch"
+        Write-Host "âœ… Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -155,7 +156,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -237,7 +238,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "✅ Found gRPC binary: $grpcMatch"
+        Write-Host "âœ… Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -245,7 +246,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'public/upstream-public'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
 - task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
+  displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -72,7 +72,7 @@ steps:
 - bash: |
     pip install pip-audit
     cd workers
-    pip-audit -r requirements.txt
+    pip-audit --vulnerability-service osv .
   displayName: 'Run vulnerability scan'
   continueOnError: true
 - task: CopyFiles@2

--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -70,12 +70,6 @@ steps:
 #     args: '${{ parameters.pythonVersion }}'
 #   displayName: 'Build dependencies from source'
 #   condition: eq(variables['isRC'], 'true')
-- bash: |
-    pip install pip-audit
-    cd workers
-    pip-audit --vulnerability-service osv .
-  displayName: 'Run vulnerability scan'
-  continueOnError: true
 - task: CopyFiles@2
   inputs:
     contents: '$(workerPath)'

--- a/eng/pack/templates/macos_64_env_gen.yml
+++ b/eng/pack/templates/macos_64_env_gen.yml
@@ -142,7 +142,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "âœ… Found gRPC binary: $grpcMatch"
+        Write-Host "✅ Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -150,7 +150,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -232,7 +232,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "âœ… Found gRPC binary: $grpcMatch"
+        Write-Host "✅ Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -240,7 +240,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'public/upstream-public'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
 - task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
+  displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -72,7 +72,7 @@ steps:
 - bash: |
     pip install pip-audit
     cd workers
-    pip-audit -r requirements.txt
+    pip-audit --vulnerability-service osv .
   displayName: 'Run vulnerability scan'
   continueOnError: true
 - task: CopyFiles@2

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -142,7 +142,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "âœ… Found gRPC binary: $grpcMatch"
+        Write-Host "✅ Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -150,7 +150,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -222,7 +222,7 @@ steps:
     # if (-not $grpcMatch) {
     #     $missing += "grpc/_cython/$grpcPattern"
     # } else {
-    #     Write-Host "âœ… Found gRPC binary: $grpcMatch"
+    #     Write-Host "✅ Found gRPC binary: $grpcMatch"
     # }
 
     if ($missing.Count -gt 0) {
@@ -230,7 +230,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -8,6 +8,7 @@ steps:
   displayName: 'Pip Authenticate'
   inputs:
     artifactFeeds: 'internal/upstream'
+    onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -147,7 +148,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "✅ Found gRPC binary: $grpcMatch"
+        Write-Host "âœ… Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -155,7 +156,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -227,7 +228,7 @@ steps:
     # if (-not $grpcMatch) {
     #     $missing += "grpc/_cython/$grpcPattern"
     # } else {
-    #     Write-Host "✅ Found gRPC binary: $grpcMatch"
+    #     Write-Host "âœ… Found gRPC binary: $grpcMatch"
     # }
 
     if ($missing.Count -gt 0) {
@@ -235,7 +236,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/pack/templates/nix_arm64_env_gen.yml
+++ b/eng/pack/templates/nix_arm64_env_gen.yml
@@ -70,12 +70,6 @@ steps:
     args: '${{ parameters.pythonVersion }}'
   displayName: 'Build dependencies from scratch'
   condition: eq(variables['isRC'], 'true')
-- bash: |
-    pip install pip-audit
-    cd workers
-    pip-audit --vulnerability-service osv .
-  displayName: 'Run vulnerability scan'
-  continueOnError: true
 - task: CopyFiles@2
   inputs:
     contents: '$(workerPath)'

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -142,7 +142,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "âœ… Found gRPC binary: $grpcMatch"
+        Write-Host "✅ Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -150,7 +150,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -223,7 +223,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "âœ… Found gRPC binary: $grpcMatch"
+        Write-Host "✅ Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -231,7 +231,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'public/upstream-public'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
 - task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
+  displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -72,7 +72,7 @@ steps:
 - bash: |
     pip install pip-audit
     cd workers
-    pip-audit -r requirements.txt
+    pip-audit --vulnerability-service osv .
   displayName: 'Run vulnerability scan'
   continueOnError: true
 - task: CopyFiles@2

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -8,6 +8,7 @@ steps:
   displayName: 'Pip Authenticate'
   inputs:
     artifactFeeds: 'internal/upstream'
+    onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -147,7 +148,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "✅ Found gRPC binary: $grpcMatch"
+        Write-Host "âœ… Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -155,7 +156,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -228,7 +229,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "✅ Found gRPC binary: $grpcMatch"
+        Write-Host "âœ… Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -236,7 +237,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/pack/templates/nix_env_gen.yml
+++ b/eng/pack/templates/nix_env_gen.yml
@@ -70,12 +70,6 @@ steps:
 #     args: '${{ parameters.pythonVersion }}'
 #   displayName: 'Build dependencies from source'
 #   condition: eq(variables['isRC'], 'true')
-- bash: |
-    pip install pip-audit
-    cd workers
-    pip-audit --vulnerability-service osv .
-  displayName: 'Run vulnerability scan'
-  continueOnError: true
 - task: CopyFiles@2
   inputs:
     contents: '$(workerPath)'

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/upstream'
+    artifactFeeds: 'public/upstream-public'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
 - task: PipAuthenticate@1
-  displayName: 'Pip Authenticate'
+  displayName: 'Authenticate pip to CFS'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
     onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -69,12 +69,6 @@ steps:
 #     arguments: '${{ parameters.pythonVersion }}'
 #   displayName: 'Build dependencies from source'
 #   condition: eq(variables['isRC'], 'true')
-- bash: |
-    pip install pip-audit
-    cd workers
-    pip-audit --vulnerability-service osv .
-  displayName: 'Run vulnerability scan'
-  continueOnError: true
 - task: CopyFiles@2
   inputs:
     contents: '$(workerPath)'

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -141,7 +141,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "âœ… Found gRPC binary: $grpcMatch"
+        Write-Host "✅ Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -149,7 +149,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -229,7 +229,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "âœ… Found gRPC binary: $grpcMatch"
+        Write-Host "✅ Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -237,7 +237,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "âœ… Validation passed. All expected files/folders are present."
+        Write-Host "✅ Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -7,7 +7,7 @@ steps:
 - task: PipAuthenticate@1
   displayName: 'Pip Authenticate'
   inputs:
-    artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+    artifactFeeds: 'internal/upstream'
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -71,7 +71,7 @@ steps:
 - bash: |
     pip install pip-audit
     cd workers
-    pip-audit -r requirements.txt
+    pip-audit --vulnerability-service osv .
   displayName: 'Run vulnerability scan'
   continueOnError: true
 - task: CopyFiles@2

--- a/eng/pack/templates/win_env_gen.yml
+++ b/eng/pack/templates/win_env_gen.yml
@@ -8,6 +8,7 @@ steps:
   displayName: 'Pip Authenticate'
   inputs:
     artifactFeeds: 'internal/upstream'
+    onlyAddExtraIndex: false
 - task: UsePythonVersion@0
   inputs:
     versionSpec: ${{ parameters.pythonVersion }}
@@ -146,7 +147,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "✅ Found gRPC binary: $grpcMatch"
+        Write-Host "âœ… Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -154,7 +155,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate azure_functions_worker artifact contents"
   condition: eq(variables['proxyWorker'], false)
@@ -234,7 +235,7 @@ steps:
     if (-not $grpcMatch) {
         $missing += "grpc/_cython/$grpcPattern"
     } else {
-        Write-Host "✅ Found gRPC binary: $grpcMatch"
+        Write-Host "âœ… Found gRPC binary: $grpcMatch"
     }
 
     if ($missing.Count -gt 0) {
@@ -242,7 +243,7 @@ steps:
         exit 1
     }
     else {
-        Write-Host "✅ Validation passed. All expected files/folders are present."
+        Write-Host "âœ… Validation passed. All expected files/folders are present."
     }
   displayName: "Validate proxy_worker artifact contents"
   condition: eq(variables['proxyWorker'], true)

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-# Route all installs through the internal Azure Artifacts feed instead of pypi.org.
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-export UV_INDEX_URL="$PIP_INDEX_URL"
+# Route uv through the internal Azure Artifacts feed. PipAuthenticate handles
+# pip's auth separately; setting PIP_INDEX_URL would override that and hang.
+export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
 export UV_KEYRING_PROVIDER=subprocess
-echo "Using index: $PIP_INDEX_URL"
+echo "UV index: $UV_INDEX_URL"
 
 # Install uv for faster dependency resolution / installation.
 python -m pip install --upgrade pip

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 set -e
 
-# Route uv through the internal Azure Artifacts feed. PipAuthenticate handles
-# pip's auth separately; setting PIP_INDEX_URL would override that and hang.
-# UV_FEED_URL is set by the pipeline step env block based on the ArtifactFeed parameter.
-_feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
-if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-else
-    export UV_INDEX_URL="$_feed"
+# Forward PipAuthenticate's index URL to uv, which does not read pip's config.
+if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+  export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
 fi
-echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
 
 # Install uv for faster dependency resolution / installation.
 python -m pip install --upgrade pip

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 set -e
 
-# Forward the PipAuthenticate-supplied feed URL to uv. PipAuthenticate@1 sets
-# PIP_EXTRA_INDEX_URL so that pip uses the internal feed, but uv does not read
-# pip's config or environment variables. Setting UV_INDEX_URL makes uv use the
-# internal feed as its primary index instead of going directly to pypi.org.
-if [ -n "${PIP_EXTRA_INDEX_URL:-}" ]; then
-    export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
-fi
-
 # Install uv for faster dependency resolution / installation.
 python -m pip install --upgrade pip
 python -m pip install uv
+
+# PipAuthenticate@1 writes the authenticated feed URL to pip's config file but
+# does not expose it as a plain env var (the URL contains a PAT token). uv does
+# not read pip's config, so extract the URL here and forward it via UV_INDEX_URL.
+_uv_index=$(python -m pip config get global.index-url 2>/dev/null || \
+            python -m pip config get global.extra-index-url 2>/dev/null || true)
+[ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
 
 # Use uv as a drop-in replacement for pip. `--system` installs into the active
 # Python environment (the agent's Python), matching previous `pip install` behavior.

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Forward the PipAuthenticate-supplied feed URL to uv. PipAuthenticate@1 sets
+# PIP_EXTRA_INDEX_URL so that pip uses the internal feed, but uv does not read
+# pip's config or environment variables. Setting UV_INDEX_URL makes uv use the
+# internal feed as its primary index instead of going directly to pypi.org.
+if [ -n "${PIP_EXTRA_INDEX_URL:-}" ]; then
+    export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
+fi
+
 # Install uv for faster dependency resolution / installation.
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -1,26 +1,11 @@
 #!/bin/bash
 set -e
 
-# PipAuthenticate@1 writes the feed URL to pip.conf and installs artifacts-keyring
-# for auth, but does not expose the URL as a plain env var. Read it from pip.conf
-# before any installs so pip (PIP_INDEX_URL) and uv (UV_INDEX_URL) both use the
-# internal feed. UV_KEYRING_PROVIDER=subprocess delegates uv auth to artifacts-keyring.
-echo "--- pip index configuration ---"
-for _f in /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini"; do
-    if [ -f "$_f" ]; then echo "  found: $_f"; else echo "  not found: $_f"; fi
-done
-_feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' \
-                /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" \
-                2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-if [ -n "$_feed_url" ]; then
-    echo "  feed URL: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-    echo "  setting PIP_INDEX_URL, UV_INDEX_URL, UV_KEYRING_PROVIDER=subprocess"
-    export PIP_INDEX_URL="$_feed_url"
-    export UV_INDEX_URL="$_feed_url"
-    export UV_KEYRING_PROVIDER=subprocess
-else
-    echo "  no internal feed detected; installs will use PyPI"
-fi
+# Route all installs through the internal Azure Artifacts feed instead of pypi.org.
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+export UV_INDEX_URL="$PIP_INDEX_URL"
+export UV_KEYRING_PROVIDER=subprocess
+echo "Using index: $PIP_INDEX_URL"
 
 # Install uv for faster dependency resolution / installation.
 python -m pip install --upgrade pip

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -3,10 +3,10 @@ set -e
 
 # Route uv through the internal Azure Artifacts feed. PipAuthenticate handles
 # pip's auth separately; setting PIP_INDEX_URL would override that and hang.
-# SYSTEM_ACCESSTOKEN is mapped from $(System.AccessToken) by the pipeline step's env block.
-_feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+# UV_FEED_URL is set by the pipeline step env block based on the ArtifactFeed parameter.
+_feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
 if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
 else
     export UV_INDEX_URL="$_feed"
 fi

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -35,7 +35,7 @@ fi
 
 # Install everything else in a single uv invocation so the resolver runs once
 # and all wheels are downloaded in parallel.
-$UV_PIP -U --prerelease=allow \
+$UV_PIP -U --prerelease=if-necessary-or-explicit \
     azure-functions \
     -e "$2/[dev]" \
     -e "$2/[test-http-v2]" \

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -3,9 +3,14 @@ set -e
 
 # Route uv through the internal Azure Artifacts feed. PipAuthenticate handles
 # pip's auth separately; setting PIP_INDEX_URL would override that and hang.
-export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-export UV_KEYRING_PROVIDER=subprocess
-echo "UV index: $UV_INDEX_URL"
+# SYSTEM_ACCESSTOKEN is mapped from $(System.AccessToken) by the pipeline step's env block.
+_feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+else
+    export UV_INDEX_URL="$_feed"
+fi
+echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
 
 # Install uv for faster dependency resolution / installation.
 python -m pip install --upgrade pip

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
 set -e
 
+# PipAuthenticate@1 writes the feed URL to pip.conf and installs artifacts-keyring
+# for auth, but does not expose the URL as a plain env var. Read it from pip.conf
+# before any installs so pip (PIP_INDEX_URL) and uv (UV_INDEX_URL) both use the
+# internal feed. UV_KEYRING_PROVIDER=subprocess delegates uv auth to artifacts-keyring.
+echo "--- pip index configuration ---"
+for _f in /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini"; do
+    if [ -f "$_f" ]; then echo "  found: $_f"; else echo "  not found: $_f"; fi
+done
+_feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' \
+                /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" \
+                2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+if [ -n "$_feed_url" ]; then
+    echo "  feed URL: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+    echo "  setting PIP_INDEX_URL, UV_INDEX_URL, UV_KEYRING_PROVIDER=subprocess"
+    export PIP_INDEX_URL="$_feed_url"
+    export UV_INDEX_URL="$_feed_url"
+    export UV_KEYRING_PROVIDER=subprocess
+else
+    echo "  no internal feed detected; installs will use PyPI"
+fi
+
 # Install uv for faster dependency resolution / installation.
 python -m pip install --upgrade pip
 python -m pip install uv
-
-# PipAuthenticate@1 writes the authenticated feed URL to pip's config file but
-# does not expose it as a plain env var (the URL contains a PAT token). uv does
-# not read pip's config, so extract the URL here and forward it via UV_INDEX_URL.
-_uv_index=$(python -m pip config get global.index-url 2>/dev/null || \
-            python -m pip config get global.extra-index-url 2>/dev/null || true)
-[ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
 
 # Use uv as a drop-in replacement for pip. `--system` installs into the active
 # Python environment (the agent's Python), matching previous `pip install` behavior.

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Route all installs through the internal Azure Artifacts feed instead of pypi.org.
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
 export UV_INDEX_URL="$PIP_INDEX_URL"
 export UV_KEYRING_PROVIDER=subprocess
 echo "Using index: $PIP_INDEX_URL"

--- a/eng/scripts/install-dependencies.sh
+++ b/eng/scripts/install-dependencies.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Route all installs through the internal Azure Artifacts feed instead of pypi.org.
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
 export UV_INDEX_URL="$PIP_INDEX_URL"
 export UV_KEYRING_PROVIDER=subprocess
 echo "Using index: $PIP_INDEX_URL"

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Forward the PipAuthenticate-supplied feed URL to uv. PipAuthenticate@1 sets
+# PIP_EXTRA_INDEX_URL so that pip uses the internal feed, but uv does not read
+# pip's config or environment variables. Setting UV_INDEX_URL makes uv use the
+# internal feed as its primary index instead of going directly to pypi.org.
+if [ -n "${PIP_EXTRA_INDEX_URL:-}" ]; then
+    export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
+fi
+
 python -m pip install --upgrade pip
 python -m pip install uv
 

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -e
 
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-export UV_INDEX_URL="$PIP_INDEX_URL"
+export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
 export UV_KEYRING_PROVIDER=subprocess
-echo "Using index: $PIP_INDEX_URL"
+echo "UV index: $UV_INDEX_URL"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -16,7 +16,7 @@ UV_PIP="python -m uv pip install --system"
 
 $UV_PIP "setuptools>=62,<82.0"
 $UV_PIP -e $1/PythonExtensionArtifact/$3
-$UV_PIP --prerelease=allow -e workers/[test-http-v2]
-$UV_PIP -U --prerelease=allow -e workers/[test-deferred-bindings]
+$UV_PIP --prerelease=if-necessary-or-explicit -e workers/[test-http-v2]
+$UV_PIP -U --prerelease=if-necessary-or-explicit -e workers/[test-deferred-bindings]
 
 $UV_PIP -U -e workers/[dev]

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,22 +1,10 @@
 #!/bin/bash
 set -e
 
-echo "--- pip index configuration ---"
-for _f in /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini"; do
-    if [ -f "$_f" ]; then echo "  found: $_f"; else echo "  not found: $_f"; fi
-done
-_feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' \
-                /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" \
-                2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-if [ -n "$_feed_url" ]; then
-    echo "  feed URL: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-    echo "  setting PIP_INDEX_URL, UV_INDEX_URL, UV_KEYRING_PROVIDER=subprocess"
-    export PIP_INDEX_URL="$_feed_url"
-    export UV_INDEX_URL="$_feed_url"
-    export UV_KEYRING_PROVIDER=subprocess
-else
-    echo "  no internal feed detected; installs will use PyPI"
-fi
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+export UV_INDEX_URL="$PIP_INDEX_URL"
+export UV_KEYRING_PROVIDER=subprocess
+echo "Using index: $PIP_INDEX_URL"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
 export UV_INDEX_URL="$PIP_INDEX_URL"
 export UV_KEYRING_PROVIDER=subprocess
 echo "Using index: $PIP_INDEX_URL"

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -e
 
-export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-export UV_KEYRING_PROVIDER=subprocess
-echo "UV index: $UV_INDEX_URL"
+_feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+else
+    export UV_INDEX_URL="$_feed"
+fi
+echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 set -e
 
+echo "--- pip index configuration ---"
+for _f in /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini"; do
+    if [ -f "$_f" ]; then echo "  found: $_f"; else echo "  not found: $_f"; fi
+done
+_feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' \
+                /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" \
+                2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+if [ -n "$_feed_url" ]; then
+    echo "  feed URL: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+    echo "  setting PIP_INDEX_URL, UV_INDEX_URL, UV_KEYRING_PROVIDER=subprocess"
+    export PIP_INDEX_URL="$_feed_url"
+    export UV_INDEX_URL="$_feed_url"
+    export UV_KEYRING_PROVIDER=subprocess
+else
+    echo "  no internal feed detected; installs will use PyPI"
+fi
+
 python -m pip install --upgrade pip
 python -m pip install uv
-
-# PipAuthenticate@1 writes the authenticated feed URL to pip's config file but
-# does not expose it as a plain env var (the URL contains a PAT token). uv does
-# not read pip's config, so extract the URL here and forward it via UV_INDEX_URL.
-_uv_index=$(python -m pip config get global.index-url 2>/dev/null || \
-            python -m pip config get global.extra-index-url 2>/dev/null || true)
-[ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
 
 UV_PIP="python -m uv pip install --system"
 

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
 export UV_INDEX_URL="$PIP_INDEX_URL"
 export UV_KEYRING_PROVIDER=subprocess
 echo "Using index: $PIP_INDEX_URL"

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-# Forward the PipAuthenticate-supplied feed URL to uv. PipAuthenticate@1 sets
-# PIP_EXTRA_INDEX_URL so that pip uses the internal feed, but uv does not read
-# pip's config or environment variables. Setting UV_INDEX_URL makes uv use the
-# internal feed as its primary index instead of going directly to pypi.org.
-if [ -n "${PIP_EXTRA_INDEX_URL:-}" ]; then
-    export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
-fi
-
 python -m pip install --upgrade pip
 python -m pip install uv
+
+# PipAuthenticate@1 writes the authenticated feed URL to pip's config file but
+# does not expose it as a plain env var (the URL contains a PAT token). uv does
+# not read pip's config, so extract the URL here and forward it via UV_INDEX_URL.
+_uv_index=$(python -m pip config get global.index-url 2>/dev/null || \
+            python -m pip config get global.extra-index-url 2>/dev/null || true)
+[ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
 
 UV_PIP="python -m uv pip install --system"
 

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -e
 
-_feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
-if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-else
-    export UV_INDEX_URL="$_feed"
+if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+  export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
 fi
-echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-extensions.sh
+++ b/eng/scripts/test-extensions.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-_feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+_feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
 if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
 else
     export UV_INDEX_URL="$_feed"
 fi

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Forward the PipAuthenticate-supplied feed URL to uv. PipAuthenticate@1 sets
+# PIP_EXTRA_INDEX_URL so that pip uses the internal feed, but uv does not read
+# pip's config or environment variables. Setting UV_INDEX_URL makes uv use the
+# internal feed as its primary index instead of going directly to pypi.org.
+if [ -n "${PIP_EXTRA_INDEX_URL:-}" ]; then
+    export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
+fi
+
 python -m pip install --upgrade pip
 python -m pip install uv
 

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -e
 
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-export UV_INDEX_URL="$PIP_INDEX_URL"
+export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
 export UV_KEYRING_PROVIDER=subprocess
-echo "Using index: $PIP_INDEX_URL"
+echo "UV index: $UV_INDEX_URL"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,22 +1,10 @@
 #!/bin/bash
 set -e
 
-echo "--- pip index configuration ---"
-for _f in /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini"; do
-    if [ -f "$_f" ]; then echo "  found: $_f"; else echo "  not found: $_f"; fi
-done
-_feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' \
-                /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" \
-                2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-if [ -n "$_feed_url" ]; then
-    echo "  feed URL: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-    echo "  setting PIP_INDEX_URL, UV_INDEX_URL, UV_KEYRING_PROVIDER=subprocess"
-    export PIP_INDEX_URL="$_feed_url"
-    export UV_INDEX_URL="$_feed_url"
-    export UV_KEYRING_PROVIDER=subprocess
-else
-    echo "  no internal feed detected; installs will use PyPI"
-fi
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+export UV_INDEX_URL="$PIP_INDEX_URL"
+export UV_KEYRING_PROVIDER=subprocess
+echo "Using index: $PIP_INDEX_URL"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
 export UV_INDEX_URL="$PIP_INDEX_URL"
 export UV_KEYRING_PROVIDER=subprocess
 echo "Using index: $PIP_INDEX_URL"

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -e
 
-export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-export UV_KEYRING_PROVIDER=subprocess
-echo "UV index: $UV_INDEX_URL"
+_feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+else
+    export UV_INDEX_URL="$_feed"
+fi
+echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 set -e
 
+echo "--- pip index configuration ---"
+for _f in /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini"; do
+    if [ -f "$_f" ]; then echo "  found: $_f"; else echo "  not found: $_f"; fi
+done
+_feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' \
+                /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" \
+                2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+if [ -n "$_feed_url" ]; then
+    echo "  feed URL: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+    echo "  setting PIP_INDEX_URL, UV_INDEX_URL, UV_KEYRING_PROVIDER=subprocess"
+    export PIP_INDEX_URL="$_feed_url"
+    export UV_INDEX_URL="$_feed_url"
+    export UV_KEYRING_PROVIDER=subprocess
+else
+    echo "  no internal feed detected; installs will use PyPI"
+fi
+
 python -m pip install --upgrade pip
 python -m pip install uv
-
-# PipAuthenticate@1 writes the authenticated feed URL to pip's config file but
-# does not expose it as a plain env var (the URL contains a PAT token). uv does
-# not read pip's config, so extract the URL here and forward it via UV_INDEX_URL.
-_uv_index=$(python -m pip config get global.index-url 2>/dev/null || \
-            python -m pip config get global.extra-index-url 2>/dev/null || true)
-[ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
 
 UV_PIP="python -m uv pip install --system"
 

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -18,5 +18,5 @@ $UV_PIP "setuptools>=62,<82.0"
 $UV_PIP -e $1/PythonSdkArtifact
 $UV_PIP -e workers/[dev]
 
-$UV_PIP -U --prerelease=allow -e workers/[test-http-v2]
-$UV_PIP -U --prerelease=allow -e workers/[test-deferred-bindings]
+$UV_PIP -U --prerelease=if-necessary-or-explicit -e workers/[test-http-v2]
+$UV_PIP -U --prerelease=if-necessary-or-explicit -e workers/[test-deferred-bindings]

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
 export UV_INDEX_URL="$PIP_INDEX_URL"
 export UV_KEYRING_PROVIDER=subprocess
 echo "Using index: $PIP_INDEX_URL"

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 set -e
 
-# Forward the PipAuthenticate-supplied feed URL to uv. PipAuthenticate@1 sets
-# PIP_EXTRA_INDEX_URL so that pip uses the internal feed, but uv does not read
-# pip's config or environment variables. Setting UV_INDEX_URL makes uv use the
-# internal feed as its primary index instead of going directly to pypi.org.
-if [ -n "${PIP_EXTRA_INDEX_URL:-}" ]; then
-    export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
-fi
-
 python -m pip install --upgrade pip
 python -m pip install uv
+
+# PipAuthenticate@1 writes the authenticated feed URL to pip's config file but
+# does not expose it as a plain env var (the URL contains a PAT token). uv does
+# not read pip's config, so extract the URL here and forward it via UV_INDEX_URL.
+_uv_index=$(python -m pip config get global.index-url 2>/dev/null || \
+            python -m pip config get global.extra-index-url 2>/dev/null || true)
+[ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
 
 UV_PIP="python -m uv pip install --system"
 

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 set -e
 
-_feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
-if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-else
-    export UV_INDEX_URL="$_feed"
+if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+  export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
 fi
-echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
 
 python -m pip install --upgrade pip
 python -m pip install uv

--- a/eng/scripts/test-sdk.sh
+++ b/eng/scripts/test-sdk.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-_feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+_feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
 if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+    export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
 else
     export UV_INDEX_URL="$_feed"
 fi

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -19,4 +19,4 @@ jobs:
           PYTHON_VERSION: ${{ parameters.PYTHON_VERSION }}
           PROJECT_NAME: ${{ parameters.PROJECT_NAME }}
           PROJECT_DIRECTORY: ${{ parameters.PROJECT_DIRECTORY }}
-          ArtifactFeed: 'public/PythonWorker_PublicPackages'
+          ArtifactFeed: 'public/upstream-public'

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -19,4 +19,4 @@ jobs:
           PYTHON_VERSION: ${{ parameters.PYTHON_VERSION }}
           PROJECT_NAME: ${{ parameters.PROJECT_NAME }}
           PROJECT_DIRECTORY: ${{ parameters.PROJECT_DIRECTORY }}
-          ArtifactFeed: 'public/upstream-public'
+          

--- a/eng/templates/jobs/build.yml
+++ b/eng/templates/jobs/build.yml
@@ -19,4 +19,4 @@ jobs:
           PYTHON_VERSION: ${{ parameters.PYTHON_VERSION }}
           PROJECT_NAME: ${{ parameters.PROJECT_NAME }}
           PROJECT_DIRECTORY: ${{ parameters.PROJECT_DIRECTORY }}
-          ArtifactFeed: 'public/upstream-public'
+          ArtifactFeed: 'public/PythonWorker_PublicPackages'

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,9 +54,9 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
-            echo "Using index: $PIP_INDEX_URL"
+            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            export UV_KEYRING_PROVIDER=subprocess
+            echo "UV index: $UV_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -67,12 +67,14 @@ jobs:
             cd ..
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_worker.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_worker'])]"
         displayName: 'Python Azure Functions Worker: check for missing dependencies'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
-            echo "Using index: $PIP_INDEX_URL"
+            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            export UV_KEYRING_PROVIDER=subprocess
+            echo "UV index: $UV_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -82,28 +84,34 @@ jobs:
             cd ..
             python -c "import pkgutil, importlib; [importlib.import_module(f'proxy_worker.{name}') for _, name, _ in pkgutil.walk_packages(['proxy_worker'])]"
         displayName: 'Python Proxy Worker: check for missing dependencies'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
-            echo "Using index: $PIP_INDEX_URL"
+            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            export UV_KEYRING_PROVIDER=subprocess
+            echo "UV index: $UV_INDEX_URL"
             cd runtimes/v1
             python -m pip install --upgrade pip
             python -m pip install uv
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime_v1.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime_v1'])]"
         displayName: 'Python Library V1: check for missing dependencies'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
-            echo "Using index: $PIP_INDEX_URL"
+            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            export UV_KEYRING_PROVIDER=subprocess
+            echo "UV index: $UV_INDEX_URL"
             cd runtimes/v2
             python -m pip install --upgrade pip
             python -m pip install uv
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime'])]"
         displayName: 'Python Library V2: check for missing dependencies'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: eq(variables['proxyWorker'], true)

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -1,5 +1,4 @@
 parameters:
-  ArtifactFeed: ''
 
 jobs:
   - job: "TestPython"
@@ -28,7 +27,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -4,13 +4,6 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run Dependency Checks"
-    variables:
-      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
-      - ${{ else }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -61,13 +54,9 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
-            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
-            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-            else
-                export UV_INDEX_URL="$_feed"
+            if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+              export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
             fi
-            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -78,19 +67,12 @@ jobs:
             cd ..
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_worker.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_worker'])]"
         displayName: 'Python Azure Functions Worker: check for missing dependencies'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
-            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
-            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-            else
-                export UV_INDEX_URL="$_feed"
+            if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+              export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
             fi
-            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -100,45 +82,28 @@ jobs:
             cd ..
             python -c "import pkgutil, importlib; [importlib.import_module(f'proxy_worker.{name}') for _, name, _ in pkgutil.walk_packages(['proxy_worker'])]"
         displayName: 'Python Proxy Worker: check for missing dependencies'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
-            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
-            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-            else
-                export UV_INDEX_URL="$_feed"
+            if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+              export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
             fi
-            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd runtimes/v1
             python -m pip install --upgrade pip
             python -m pip install uv
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime_v1.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime_v1'])]"
         displayName: 'Python Library V1: check for missing dependencies'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
-            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
-            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-            else
-                export UV_INDEX_URL="$_feed"
+            if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+              export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
             fi
-            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd runtimes/v2
             python -m pip install --upgrade pip
             python -m pip install uv
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime'])]"
         displayName: 'Python Library V2: check for missing dependencies'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], true)

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,11 +54,16 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
+            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+            if [ -n "$_feed_url" ]; then
+                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
+            else
+                echo "No internal feed detected; installs will use PyPI"
+            fi
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
-            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
-            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system "setuptools<82.0"
             python -m uv pip install --system . invoke
             cd tests
@@ -69,11 +74,16 @@ jobs:
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
+            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+            if [ -n "$_feed_url" ]; then
+                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
+            else
+                echo "No internal feed detected; installs will use PyPI"
+            fi
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
-            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
-            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system . invoke
             cd tests
             python -m invoke -c test_setup build-protos
@@ -83,22 +93,32 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
+            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+            if [ -n "$_feed_url" ]; then
+                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
+            else
+                echo "No internal feed detected; installs will use PyPI"
+            fi
             cd runtimes/v1
             python -m pip install --upgrade pip
             python -m pip install uv
-            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
-            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime_v1.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime_v1'])]"
         displayName: 'Python Library V1: check for missing dependencies'
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
+            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+            if [ -n "$_feed_url" ]; then
+                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
+            else
+                echo "No internal feed detected; installs will use PyPI"
+            fi
             cd runtimes/v2
             python -m pip install --upgrade pip
             python -m pip install uv
-            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
-            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime'])]"
         displayName: 'Python Library V2: check for missing dependencies'

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,9 +54,12 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
-            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_KEYRING_PROVIDER=subprocess
-            echo "UV index: $UV_INDEX_URL"
+            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            else
+                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            fi
+            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -72,9 +75,12 @@ jobs:
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
-            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_KEYRING_PROVIDER=subprocess
-            echo "UV index: $UV_INDEX_URL"
+            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            else
+                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            fi
+            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -89,9 +95,12 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
-            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_KEYRING_PROVIDER=subprocess
-            echo "UV index: $UV_INDEX_URL"
+            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            else
+                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            fi
+            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd runtimes/v1
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -103,9 +112,12 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
-            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-            export UV_KEYRING_PROVIDER=subprocess
-            echo "UV index: $UV_INDEX_URL"
+            if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            else
+                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            fi
+            echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd runtimes/v2
             python -m pip install --upgrade pip
             python -m pip install uv

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,10 +54,11 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
-            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
+            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
+            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system "setuptools<82.0"
             python -m uv pip install --system . invoke
             cd tests
@@ -68,10 +69,11 @@ jobs:
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
-            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
+            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
+            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system . invoke
             cd tests
             python -m invoke -c test_setup build-protos
@@ -81,20 +83,22 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
-            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd runtimes/v1
             python -m pip install --upgrade pip
             python -m pip install uv
+            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
+            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime_v1.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime_v1'])]"
         displayName: 'Python Library V1: check for missing dependencies'
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
-            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd runtimes/v2
             python -m pip install --upgrade pip
             python -m pip install uv
+            _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
+            [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
             python -m uv pip install --system .
             python -c "import pkgutil, importlib; [importlib.import_module(f'azure_functions_runtime.{name}') for _, name, _ in pkgutil.walk_packages(['azure_functions_runtime'])]"
         displayName: 'Python Library V2: check for missing dependencies'

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -4,6 +4,13 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run Dependency Checks"
+    variables:
+      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
+      - ${{ else }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -54,10 +61,11 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
+            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
             if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
             else
-                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="$_feed"
             fi
             echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd workers
@@ -72,13 +80,15 @@ jobs:
         displayName: 'Python Azure Functions Worker: check for missing dependencies'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
+            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
             if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
             else
-                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="$_feed"
             fi
             echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd workers
@@ -92,13 +102,15 @@ jobs:
         displayName: 'Python Proxy Worker: check for missing dependencies'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
+            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
             if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
             else
-                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="$_feed"
             fi
             echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd runtimes/v1
@@ -109,13 +121,15 @@ jobs:
         displayName: 'Python Library V1: check for missing dependencies'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
+            _feed="${UV_FEED_URL:-https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/}"
             if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
             else
-                export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+                export UV_INDEX_URL="$_feed"
             fi
             echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
             cd runtimes/v2
@@ -126,4 +140,5 @@ jobs:
         displayName: 'Python Library V2: check for missing dependencies'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: eq(variables['proxyWorker'], true)

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -29,6 +29,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,13 +54,9 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
-            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-            if [ -n "$_feed_url" ]; then
-                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
-            else
-                echo "No internal feed detected; installs will use PyPI"
-            fi
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
+            echo "Using index: $PIP_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -74,13 +70,9 @@ jobs:
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
-            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-            if [ -n "$_feed_url" ]; then
-                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
-            else
-                echo "No internal feed detected; installs will use PyPI"
-            fi
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
+            echo "Using index: $PIP_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -93,13 +85,9 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
-            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-            if [ -n "$_feed_url" ]; then
-                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
-            else
-                echo "No internal feed detected; installs will use PyPI"
-            fi
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
+            echo "Using index: $PIP_INDEX_URL"
             cd runtimes/v1
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -109,13 +97,9 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
-            _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-            if [ -n "$_feed_url" ]; then
-                echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-                export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
-            else
-                echo "No internal feed detected; installs will use PyPI"
-            fi
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
+            echo "Using index: $PIP_INDEX_URL"
             cd runtimes/v2
             python -m pip install --upgrade pip
             python -m pip install uv

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -1,5 +1,3 @@
-parameters:
-
 jobs:
   - job: "TestPython"
     displayName: "Run Dependency Checks"

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,6 +54,7 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
+            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -67,6 +68,7 @@ jobs:
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
+            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd workers
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -79,6 +81,7 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
+            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd runtimes/v1
             python -m pip install --upgrade pip
             python -m pip install uv
@@ -88,6 +91,7 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
+            [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
             cd runtimes/v2
             python -m pip install --upgrade pip
             python -m pip install uv

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -26,7 +26,7 @@ jobs:
           PYTHON_VERSION: '3.14'
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
           onlyAddExtraIndex: false

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,7 +54,7 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd workers
@@ -70,7 +70,7 @@ jobs:
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd workers
@@ -85,7 +85,7 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd runtimes/v1
@@ -97,7 +97,7 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd runtimes/v2

--- a/eng/templates/jobs/ci-dependency-check.yml
+++ b/eng/templates/jobs/ci-dependency-check.yml
@@ -54,7 +54,7 @@ jobs:
         displayName: 'Set necessary variables'
       - bash: |
             echo "Checking azure_functions_worker (Python < 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd workers
@@ -70,7 +70,7 @@ jobs:
         condition: eq(variables['proxyWorker'], false)
       - bash: |
             echo "Checking proxy_worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd workers
@@ -85,7 +85,7 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V1 Library Worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd runtimes/v1
@@ -97,7 +97,7 @@ jobs:
         condition: eq(variables['proxyWorker'], true)
       - bash: |
             echo "Checking V2 Library Worker (Python >= 3.13)..."
-            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+            export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
             export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
             echo "Using index: $PIP_INDEX_URL"
             cd runtimes/v2

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -80,12 +80,12 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -28,7 +28,7 @@ jobs:
           PYTHON_VERSION: '3.14'
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
           onlyAddExtraIndex: false
@@ -78,15 +78,15 @@ jobs:
         inputs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
-        displayName: 'NuGet Authenticate'
+        displayName: 'Authenticate NuGet to CFS'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -31,6 +31,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
           df -h

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -94,6 +94,8 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install Python dependencies (uv)'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh
@@ -117,6 +119,8 @@ jobs:
           eng/scripts/test-sdk.sh $(Pipeline.Workspace) $(PYTHON_VERSION)
           eng/scripts/test-setup.sh
         displayName: 'Install test python sdk, dependencies and the worker'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: or(eq(variables.isSdkRelease, true), eq(variables['USETESTPYTHONSDK'], true))
       - task: DownloadPipelineArtifact@2
         displayName: 'Download Python Extension Artifact'
@@ -135,6 +139,8 @@ jobs:
           eng/scripts/test-extensions.sh $(Pipeline.Workspace) $(PYTHON_VERSION) $(PYTHONEXTENSIONNAME)
           eng/scripts/test-setup.sh
         displayName: 'Install test python extension, dependencies and the worker'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: or(eq(variables.isExtensionsRelease, true), eq(variables['USETESTPYTHONEXTENSIONS'], true))
       - bash: |
           # The minimal image (1es-ubuntu-24.04-min) does not ship the Docker

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -6,6 +6,13 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run Python Emulator Tests"
+    variables:
+      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
+      - ${{ else }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -96,6 +103,7 @@ jobs:
         displayName: 'Install Python dependencies (uv)'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh
@@ -121,6 +129,7 @@ jobs:
         displayName: 'Install test python sdk, dependencies and the worker'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: or(eq(variables.isSdkRelease, true), eq(variables['USETESTPYTHONSDK'], true))
       - task: DownloadPipelineArtifact@2
         displayName: 'Download Python Extension Artifact'
@@ -141,6 +150,7 @@ jobs:
         displayName: 'Install test python extension, dependencies and the worker'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: or(eq(variables.isExtensionsRelease, true), eq(variables['USETESTPYTHONEXTENSIONS'], true))
       - bash: |
           # The minimal image (1es-ubuntu-24.04-min) does not ship the Docker

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -83,10 +83,10 @@ jobs:
           # Remove the feed that doesn't match the current service connection
           if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
+            sed -i '/_Internal_PublicPackages/d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
+            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -81,7 +81,7 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
             # Remove internal feed for public builds
             sed -i '/_Internal_PublicPackages/d' nuget.config
           else

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -6,13 +6,6 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run Python Emulator Tests"
-    variables:
-      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
-      - ${{ else }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -101,9 +94,6 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install Python dependencies (uv)'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh
@@ -127,9 +117,6 @@ jobs:
           eng/scripts/test-sdk.sh $(Pipeline.Workspace) $(PYTHON_VERSION)
           eng/scripts/test-setup.sh
         displayName: 'Install test python sdk, dependencies and the worker'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: or(eq(variables.isSdkRelease, true), eq(variables['USETESTPYTHONSDK'], true))
       - task: DownloadPipelineArtifact@2
         displayName: 'Download Python Extension Artifact'
@@ -148,9 +135,6 @@ jobs:
           eng/scripts/test-extensions.sh $(Pipeline.Workspace) $(PYTHON_VERSION) $(PYTHONEXTENSIONNAME)
           eng/scripts/test-setup.sh
         displayName: 'Install test python extension, dependencies and the worker'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: or(eq(variables.isExtensionsRelease, true), eq(variables['USETESTPYTHONEXTENSIONS'], true))
       - bash: |
           # The minimal image (1es-ubuntu-24.04-min) does not ship the Docker

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -1,7 +1,5 @@
 parameters:
   PROJECT_DIRECTORY: 'workers'
-  ArtifactFeed: ''
-  NuGetServiceConnection: ''
 
 jobs:
   - job: "TestPython"
@@ -30,7 +28,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
@@ -79,18 +77,6 @@ jobs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate NuGet to CFS'
-      - bash: |
-          # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
-            # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
-          else
-            # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
-          fi
-          echo "Updated nuget.config:"
-          cat nuget.config
-        displayName: 'Configure NuGet feed for current organization'
       - bash: |
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
           onlyAddExtraIndex: false
@@ -32,15 +32,15 @@ jobs:
         inputs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
-        displayName: 'NuGet Authenticate'
+        displayName: 'Authenticate NuGet to CFS'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -34,12 +34,12 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
-            # Remove public feed for internal builds  
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            # Remove public feed for internal builds
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -37,10 +37,10 @@ jobs:
           # Remove the feed that doesn't match the current service connection
           if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
+            sed -i '/_Internal_PublicPackages/d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
+            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
             # Remove internal feed for public builds
             sed -i '/_Internal_PublicPackages/d' nuget.config
           else

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -48,6 +48,8 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh          
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install dependencies'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       - bash: |
           python -m pytest -q -n auto --dist loadfile --reruns 4 --reruns-delay 5 --instafail --cov=./${{ parameters.PROJECT_DIRECTORY }} --cov-report xml --cov-branch tests/unittests
         displayName: "Running $(PYTHON_VERSION) Unit Tests"

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -1,8 +1,6 @@
 parameters:
   PROJECT_NAME: ''
   PROJECT_DIRECTORY: ''
-  ArtifactFeed: ''
-  NuGetServiceConnection: ''
 
 jobs:
   - job: "TestPython"
@@ -22,7 +20,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
@@ -33,18 +31,6 @@ jobs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate NuGet to CFS'
-      - bash: |
-          # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
-            # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
-          else
-            # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
-          fi
-          echo "Updated nuget.config:"
-          cat nuget.config
-        displayName: 'Configure NuGet feed for current organization'
       - bash: |
           chmod +x eng/scripts/install-dependencies.sh          
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -23,6 +23,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -7,13 +7,6 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run ${{ parameters.PROJECT_NAME }} Unit Tests"
-    variables:
-      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
-      - ${{ else }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -55,9 +48,6 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh          
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install dependencies'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
       - bash: |
           python -m pytest -q -n auto --dist loadfile --reruns 4 --reruns-delay 5 --instafail --cov=./${{ parameters.PROJECT_DIRECTORY }} --cov-report xml --cov-branch tests/unittests
         displayName: "Running $(PYTHON_VERSION) Unit Tests"

--- a/eng/templates/jobs/ci-library-unit-tests.yml
+++ b/eng/templates/jobs/ci-library-unit-tests.yml
@@ -7,6 +7,13 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run ${{ parameters.PROJECT_NAME }} Unit Tests"
+    variables:
+      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
+      - ${{ else }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -50,6 +57,7 @@ jobs:
         displayName: 'Install dependencies'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
       - bash: |
           python -m pytest -q -n auto --dist loadfile --reruns 4 --reruns-delay 5 --instafail --cov=./${{ parameters.PROJECT_DIRECTORY }} --cov-report xml --cov-branch tests/unittests
         displayName: "Running $(PYTHON_VERSION) Unit Tests"

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -6,6 +6,13 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run Python Unit Tests"
+    variables:
+      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
+      - ${{ else }}:
+        - name: pyFeedUrl
+          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -99,6 +106,7 @@ jobs:
         displayName: 'Install Python dependencies (uv)'
         env:
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          UV_FEED_URL: $(pyFeedUrl)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -83,12 +83,12 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -86,10 +86,10 @@ jobs:
           # Remove the feed that doesn't match the current service connection
           if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
+            sed -i '/_Internal_PublicPackages/d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
+            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -31,6 +31,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
+          onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
           df -h

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -6,13 +6,6 @@ parameters:
 jobs:
   - job: "TestPython"
     displayName: "Run Python Unit Tests"
-    variables:
-      - ${{ if eq(parameters.ArtifactFeed, 'public/PythonWorker_PublicPackages') }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/'
-      - ${{ else }}:
-        - name: pyFeedUrl
-          value: 'https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/'
 
     pool:
       name: ${{ parameters.PoolName }}
@@ -104,9 +97,6 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install Python dependencies (uv)'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-          UV_FEED_URL: $(pyFeedUrl)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -1,7 +1,5 @@
 parameters:
   PROJECT_DIRECTORY: 'workers'
-  ArtifactFeed: ''
-  NuGetServiceConnection: ''
 
 jobs:
   - job: "TestPython"
@@ -30,7 +28,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: ${{ parameters.ArtifactFeed }}
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
@@ -82,18 +80,6 @@ jobs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate NuGet to CFS'
-      - bash: |
-          # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
-            # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
-          else
-            # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
-          fi
-          echo "Updated nuget.config:"
-          cat nuget.config
-        displayName: 'Configure NuGet feed for current organization'
       - bash: |
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -97,6 +97,8 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install Python dependencies (uv)'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
           PYTHON_VERSION: '3.14'
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
           artifactFeeds: ${{ parameters.ArtifactFeed }}
           onlyAddExtraIndex: false
@@ -81,15 +81,15 @@ jobs:
         inputs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
-        displayName: 'NuGet Authenticate'
+        displayName: 'Authenticate NuGet to CFS'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/jobs/ci-unit-tests.yml
+++ b/eng/templates/jobs/ci-unit-tests.yml
@@ -84,7 +84,7 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
             # Remove internal feed for public builds
             sed -i '/_Internal_PublicPackages/d' nuget.config
           else

--- a/eng/templates/official/jobs/build-library.yml
+++ b/eng/templates/official/jobs/build-library.yml
@@ -23,7 +23,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'public/upstream-public'
+          artifactFeeds: 'public/PythonWorker_PublicPackages'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/build-library.yml
+++ b/eng/templates/official/jobs/build-library.yml
@@ -37,9 +37,3 @@ jobs:
           cd ${{ parameters.PROJECT_DIRECTORY }}
           python -m build
         displayName: 'Build ${{ parameters.PROJECT_NAME }}'
-      - bash: |
-          pip install pip-audit
-          cd ${{ parameters.PROJECT_DIRECTORY }}
-          pip-audit --vulnerability-service osv .
-        displayName: 'Run vulnerability scan'
-        continueOnError: true

--- a/eng/templates/official/jobs/build-library.yml
+++ b/eng/templates/official/jobs/build-library.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'public/PythonWorker_PublicPackages'
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/build-library.yml
+++ b/eng/templates/official/jobs/build-library.yml
@@ -24,6 +24,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'public/upstream-public'
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: "3.13"

--- a/eng/templates/official/jobs/build-library.yml
+++ b/eng/templates/official/jobs/build-library.yml
@@ -23,7 +23,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'public/PythonWorker_PublicPackages'
+          artifactFeeds: 'public/upstream-public'
       - task: UsePythonVersion@0
         inputs:
           versionSpec: "3.13"
@@ -39,6 +39,6 @@ jobs:
       - bash: |
           pip install pip-audit
           cd ${{ parameters.PROJECT_DIRECTORY }}
-          pip-audit .
+          pip-audit --vulnerability-service osv .
         displayName: 'Run vulnerability scan'
         continueOnError: true

--- a/eng/templates/official/jobs/ci-core-tools-tests.yml
+++ b/eng/templates/official/jobs/ci-core-tools-tests.yml
@@ -13,6 +13,8 @@ jobs:
       inputs:
         artifactFeeds: 'public/upstream-public'
         onlyAddExtraIndex: false
+    - task: NuGetAuthenticate@1
+      displayName: 'Authenticate NuGet to CFS'
     - task: UsePythonVersion@0
       displayName: 'Install Python'
       inputs:

--- a/eng/templates/official/jobs/ci-core-tools-tests.yml
+++ b/eng/templates/official/jobs/ci-core-tools-tests.yml
@@ -11,7 +11,7 @@ jobs:
     - task: PipAuthenticate@1
       displayName: 'Pip Authenticate'
       inputs:
-        artifactFeeds: 'internal/upstream'
+        artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
         onlyAddExtraIndex: false
     - task: UsePythonVersion@0
       displayName: 'Install Python'

--- a/eng/templates/official/jobs/ci-core-tools-tests.yml
+++ b/eng/templates/official/jobs/ci-core-tools-tests.yml
@@ -9,9 +9,9 @@ jobs:
     
     steps:
     - task: PipAuthenticate@1
-      displayName: 'Pip Authenticate'
+      displayName: 'Authenticate pip to CFS'
       inputs:
-        artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+        artifactFeeds: 'internal/upstream'
         onlyAddExtraIndex: false
     - task: UsePythonVersion@0
       displayName: 'Install Python'

--- a/eng/templates/official/jobs/ci-core-tools-tests.yml
+++ b/eng/templates/official/jobs/ci-core-tools-tests.yml
@@ -11,7 +11,7 @@ jobs:
     - task: PipAuthenticate@1
       displayName: 'Pip Authenticate'
       inputs:
-        artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+        artifactFeeds: 'internal/upstream'
     - task: UsePythonVersion@0
       displayName: 'Install Python'
       inputs:

--- a/eng/templates/official/jobs/ci-core-tools-tests.yml
+++ b/eng/templates/official/jobs/ci-core-tools-tests.yml
@@ -11,7 +11,7 @@ jobs:
     - task: PipAuthenticate@1
       displayName: 'Authenticate pip to CFS'
       inputs:
-        artifactFeeds: 'internal/upstream'
+        artifactFeeds: 'public/upstream-public'
         onlyAddExtraIndex: false
     - task: UsePythonVersion@0
       displayName: 'Install Python'

--- a/eng/templates/official/jobs/ci-core-tools-tests.yml
+++ b/eng/templates/official/jobs/ci-core-tools-tests.yml
@@ -12,6 +12,7 @@ jobs:
       displayName: 'Pip Authenticate'
       inputs:
         artifactFeeds: 'internal/upstream'
+        onlyAddExtraIndex: false
     - task: UsePythonVersion@0
       displayName: 'Install Python'
       inputs:

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -25,6 +25,8 @@ jobs:
           cd ${{ parameters.PROJECT_DIRECTORY }}/tests
           python -m invoke -c test_setup build-protos
         displayName: 'Install dependencies'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       - bash: |
              python -m pytest --reruns 4 -vv --instafail tests/endtoend
         env:

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -25,8 +25,6 @@ jobs:
           cd ${{ parameters.PROJECT_DIRECTORY }}/tests
           python -m invoke -c test_setup build-protos
         displayName: 'Install dependencies'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       - bash: |
              python -m pytest --reruns 4 -vv --instafail tests/endtoend
         env:

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -12,9 +12,9 @@ jobs:
     
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(CUSTOM_PYTHON_VERSION)

--- a/eng/templates/official/jobs/ci-custom-image-tests.yml
+++ b/eng/templates/official/jobs/ci-custom-image-tests.yml
@@ -15,6 +15,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'internal/upstream'
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(CUSTOM_PYTHON_VERSION)

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -42,6 +42,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'internal/upstream'
+          onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
       - task: UsePythonVersion@0
         inputs:
           versionSpec: $(PYTHON_VERSION)

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -39,9 +39,9 @@ jobs:
 
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -52,8 +52,6 @@ jobs:
           cd ${{ parameters.PROJECT_DIRECTORY }}/tests
           python -m invoke -c test_setup build-protos
         displayName: 'Install dependencies'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       - bash: |
              python -m pytest --reruns 4 -vv --instafail tests/endtoend
         env:

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -52,6 +52,8 @@ jobs:
           cd ${{ parameters.PROJECT_DIRECTORY }}/tests
           python -m invoke -c test_setup build-protos
         displayName: 'Install dependencies'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       - bash: |
              python -m pytest --reruns 4 -vv --instafail tests/endtoend
         env:

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
+++ b/eng/templates/official/jobs/ci-docker-dedicated-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
           onlyAddExtraIndex: false
       - task: UsePythonVersion@0
         inputs:

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -1,6 +1,6 @@
 parameters:
   PROJECT_DIRECTORY: 'workers'
-  NuGetServiceConnection: 'PythonWorker_Internal_PublicPackages'
+  NuGetServiceConnection: 'upstream'
 
 jobs:
   - job: "TestPython"
@@ -51,9 +51,9 @@ jobs:
           EVENTGRID_CONNECTION: $(LinuxEventGridConnectionKeyString38)
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
@@ -90,15 +90,15 @@ jobs:
         inputs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
-        displayName: 'NuGet Authenticate'
+        displayName: 'Authenticate NuGet to CFS'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
             # Remove internal feed for public builds
             sed -i '/_Internal_PublicPackages/d' nuget.config
           else

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -106,6 +106,8 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install Python dependencies (uv)'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh
@@ -129,6 +131,8 @@ jobs:
           eng/scripts/test-sdk.sh $(Pipeline.Workspace) $(PYTHON_VERSION)
           eng/scripts/test-setup.sh
         displayName: 'Install test python sdk, dependencies and the worker'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: or(eq(variables.isSdkRelease, true), eq(variables['USETESTPYTHONSDK'], true))
       - task: DownloadPipelineArtifact@2
         displayName: 'Download Python Extension Artifact'
@@ -147,6 +151,8 @@ jobs:
           eng/scripts/test-extensions.sh $(Pipeline.Workspace) $(PYTHON_VERSION) $(PYTHONEXTENSIONNAME)
           eng/scripts/test-setup.sh
         displayName: 'Install test python extension, dependencies and the worker'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: or(eq(variables.isExtensionsRelease, true), eq(variables['USETESTPYTHONEXTENSIONS'], true))
       - powershell: |
           $pipelineVarSet = "$(USETESTPYTHONSDK)"

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
       - bash: |
           echo "Disk space before cleanup:"
           df -h
@@ -92,12 +92,12 @@ jobs:
         displayName: 'NuGet Authenticate'
       - bash: |
           # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "PythonWorker_PublicPackages" ]]; then
+          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/_Internal_PublicPackages/d' nuget.config
+            sed -i '/key="upstream" /d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
+            sed -i '/key="upstream-public"/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -54,6 +54,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'internal/upstream'
+          onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
           df -h

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -1,6 +1,6 @@
 parameters:
   PROJECT_DIRECTORY: 'workers'
-  NuGetServiceConnection: 'upstream'
+  
 
 jobs:
   - job: "TestPython"
@@ -53,7 +53,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
@@ -91,18 +91,6 @@ jobs:
           version: 10.0.x
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate NuGet to CFS'
-      - bash: |
-          # Remove the feed that doesn't match the current service connection
-          if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
-            # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
-          else
-            # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
-          fi
-          echo "Updated nuget.config:"
-          cat nuget.config
-        displayName: 'Configure NuGet feed for current organization'
       - bash: |
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -106,8 +106,6 @@ jobs:
           chmod +x eng/scripts/install-dependencies.sh
           eng/scripts/install-dependencies.sh $(PYTHON_VERSION) ${{ parameters.PROJECT_DIRECTORY }}
         displayName: 'Install Python dependencies (uv)'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       - bash: |
           chmod +x eng/scripts/test-setup.sh
@@ -131,8 +129,6 @@ jobs:
           eng/scripts/test-sdk.sh $(Pipeline.Workspace) $(PYTHON_VERSION)
           eng/scripts/test-setup.sh
         displayName: 'Install test python sdk, dependencies and the worker'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: or(eq(variables.isSdkRelease, true), eq(variables['USETESTPYTHONSDK'], true))
       - task: DownloadPipelineArtifact@2
         displayName: 'Download Python Extension Artifact'
@@ -151,8 +147,6 @@ jobs:
           eng/scripts/test-extensions.sh $(Pipeline.Workspace) $(PYTHON_VERSION) $(PYTHONEXTENSIONNAME)
           eng/scripts/test-setup.sh
         displayName: 'Install test python extension, dependencies and the worker'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         condition: or(eq(variables.isExtensionsRelease, true), eq(variables['USETESTPYTHONEXTENSIONS'], true))
       - powershell: |
           $pipelineVarSet = "$(USETESTPYTHONSDK)"

--- a/eng/templates/official/jobs/ci-e2e-tests.yml
+++ b/eng/templates/official/jobs/ci-e2e-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
@@ -95,10 +95,10 @@ jobs:
           # Remove the feed that doesn't match the current service connection
           if [[ "${{ parameters.NuGetServiceConnection }}" == "upstream-public" ]]; then
             # Remove internal feed for public builds
-            sed -i '/key="upstream" /d' nuget.config
+            sed -i '/_Internal_PublicPackages/d' nuget.config
           else
             # Remove public feed for internal builds
-            sed -i '/key="upstream-public"/d' nuget.config
+            sed -i '/PythonWorker_PublicPackages[^_]/d' nuget.config
           fi
           echo "Updated nuget.config:"
           cat nuget.config

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,9 +65,9 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
-          export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-          export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
-          echo "Using index: $PIP_INDEX_URL"
+          export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+          export UV_KEYRING_PROVIDER=subprocess
+          echo "UV index: $UV_INDEX_URL"
           python -m pip install --upgrade pip
           python -m pip install uv
           UV_PIP="python -m uv pip install --system"
@@ -77,6 +77,8 @@ jobs:
           cd ${{ parameters.PROJECT_DIRECTORY }}/tests
           python -m invoke -c test_setup build-protos
         displayName: 'Install dependencies and the worker'
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         # Skip the installation stage for SDK and Extensions release branches. This stage will fail because pyproject.toml contains the updated (and unreleased) library version
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,13 +65,9 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
-          _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
-          if [ -n "$_feed_url" ]; then
-            echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
-            export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
-          else
-            echo "No internal feed detected; installs will use PyPI"
-          fi
+          export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+          export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
+          echo "Using index: $PIP_INDEX_URL"
           python -m pip install --upgrade pip
           python -m pip install uv
           UV_PIP="python -m uv pip install --system"

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,10 +65,11 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
+          _feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
           if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-            export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
           else
-            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+            export UV_INDEX_URL="$_feed"
           fi
           echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
           python -m pip install --upgrade pip

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -24,9 +24,9 @@ jobs:
            PYTHON_VERSION: '3.14'
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
           onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
       - bash: |
           echo "Disk space before cleanup:"
           df -h

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,13 +65,9 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
-          _feed="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
-          if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
-            export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@${_feed#https://}"
-          else
-            export UV_INDEX_URL="$_feed"
+          if [ -n "${PIP_INDEX_URL:-}" ] && [ -z "${UV_DEFAULT_INDEX:-}" ]; then
+            export UV_DEFAULT_INDEX="$PIP_INDEX_URL"
           fi
-          echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
           python -m pip install --upgrade pip
           python -m pip install uv
           UV_PIP="python -m uv pip install --system"
@@ -81,8 +77,6 @@ jobs:
           cd ${{ parameters.PROJECT_DIRECTORY }}/tests
           python -m invoke -c test_setup build-protos
         displayName: 'Install dependencies and the worker'
-        env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         # Skip the installation stage for SDK and Extensions release branches. This stage will fail because pyproject.toml contains the updated (and unreleased) library version
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
       

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,9 +65,12 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
-          export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
-          export UV_KEYRING_PROVIDER=subprocess
-          echo "UV index: $UV_INDEX_URL"
+          if [ -n "${SYSTEM_ACCESSTOKEN:-}" ]; then
+            export UV_INDEX_URL="https://build:${SYSTEM_ACCESSTOKEN}@pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+          else
+            export UV_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
+          fi
+          echo "UV index: $(echo "$UV_INDEX_URL" | sed 's|://[^@]*@|://***@|')"
           python -m pip install --upgrade pip
           python -m pip install uv
           UV_PIP="python -m uv pip install --system"

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,7 +65,7 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
-          export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/pypi/simple/"
+          export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
           export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
           echo "Using index: $PIP_INDEX_URL"
           python -m pip install --upgrade pip

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -27,6 +27,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'internal/upstream'
+          onlyAddExtraIndex: false
       - bash: |
           echo "Disk space before cleanup:"
           df -h

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -67,6 +67,7 @@ jobs:
       - bash: |
           python -m pip install --upgrade pip
           python -m pip install uv
+          [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
           UV_PIP="python -m uv pip install --system"
           $UV_PIP "setuptools<82.0"
           $UV_PIP -U -e ${{ parameters.PROJECT_DIRECTORY }}/[dev]

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,10 +65,15 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
+          _feed_url=$(grep -h -m1 -E '^\s*(extra-)?index-url\s*=' /etc/pip.conf "${HOME}/.config/pip/pip.conf" "${HOME}/.pip/pip.ini" 2>/dev/null | sed 's/^[^=]*=\s*//' | awk '{print $1}')
+          if [ -n "$_feed_url" ]; then
+            echo "Internal feed: $(echo "$_feed_url" | sed 's|://[^@]*@|://***@|')"
+            export PIP_INDEX_URL="$_feed_url" UV_INDEX_URL="$_feed_url" UV_KEYRING_PROVIDER=subprocess
+          else
+            echo "No internal feed detected; installs will use PyPI"
+          fi
           python -m pip install --upgrade pip
           python -m pip install uv
-          _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
-          [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
           UV_PIP="python -m uv pip install --system"
           $UV_PIP "setuptools<82.0"
           $UV_PIP -U -e ${{ parameters.PROJECT_DIRECTORY }}/[dev]

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -67,7 +67,8 @@ jobs:
       - bash: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && export UV_INDEX_URL="$PIP_EXTRA_INDEX_URL"
+          _uv_index=$(python -m pip config get global.index-url 2>/dev/null || python -m pip config get global.extra-index-url 2>/dev/null || true)
+          [ -n "$_uv_index" ] && export UV_INDEX_URL="$_uv_index"
           UV_PIP="python -m uv pip install --system"
           $UV_PIP "setuptools<82.0"
           $UV_PIP -U -e ${{ parameters.PROJECT_DIRECTORY }}/[dev]

--- a/eng/templates/official/jobs/ci-fc-tests.yml
+++ b/eng/templates/official/jobs/ci-fc-tests.yml
@@ -65,7 +65,7 @@ jobs:
         condition: and(eq(variables.isSdkRelease, false), eq(variables.isExtensionsRelease, false), eq(variables['USETESTPYTHONSDK'], false), eq(variables['USETESTPYTHONEXTENSIONS'], false))
 
       - bash: |
-          export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/pypi/simple/"
+          export PIP_INDEX_URL="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/pypi/simple/"
           export UV_INDEX_URL="$PIP_INDEX_URL" UV_KEYRING_PROVIDER=subprocess
           echo "Using index: $PIP_INDEX_URL"
           python -m pip install --upgrade pip

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -48,7 +48,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
           onlyAddExtraIndex: false
       - ${{ if ne(parameters.libraryVersion, '') }}:
         - checkout: none

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -48,7 +48,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Pip Authenticate'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
       - ${{ if ne(parameters.libraryVersion, '') }}:
         - checkout: none
         - bash: |

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -49,6 +49,7 @@ jobs:
         displayName: 'Pip Authenticate'
         inputs:
           artifactFeeds: 'internal/upstream'
+          onlyAddExtraIndex: false
       - ${{ if ne(parameters.libraryVersion, '') }}:
         - checkout: none
         - bash: |

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -46,9 +46,9 @@ jobs:
 
     steps:
       - task: PipAuthenticate@1
-        displayName: 'Pip Authenticate'
+        displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/PythonWorker_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
           onlyAddExtraIndex: false
       - ${{ if ne(parameters.libraryVersion, '') }}:
         - checkout: none

--- a/eng/templates/official/release/build-artifacts.yml
+++ b/eng/templates/official/release/build-artifacts.yml
@@ -48,7 +48,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate pip to CFS'
         inputs:
-          artifactFeeds: 'internal/upstream'
+          artifactFeeds: 'public/upstream-public'
           onlyAddExtraIndex: false
       - ${{ if ne(parameters.libraryVersion, '') }}:
         - checkout: none

--- a/eng/templates/shared/build-steps.yml
+++ b/eng/templates/shared/build-steps.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
   - task: PipAuthenticate@1
-    displayName: 'Pip Authenticate'
+    displayName: 'Authenticate pip to CFS'
     inputs:
       artifactFeeds: ${{ parameters.ArtifactFeed }}
       onlyAddExtraIndex: false

--- a/eng/templates/shared/build-steps.yml
+++ b/eng/templates/shared/build-steps.yml
@@ -2,13 +2,12 @@ parameters:
   PYTHON_VERSION: ''
   PROJECT_NAME: ''
   PROJECT_DIRECTORY: ''
-  ArtifactFeed: ''
 
 steps:
   - task: PipAuthenticate@1
     displayName: 'Authenticate pip to CFS'
     inputs:
-      artifactFeeds: ${{ parameters.ArtifactFeed }}
+      artifactFeeds: 'public/upstream-public'
       onlyAddExtraIndex: false
   - task: UsePythonVersion@0
     inputs:

--- a/eng/templates/shared/build-steps.yml
+++ b/eng/templates/shared/build-steps.yml
@@ -24,5 +24,5 @@ steps:
   - bash: |
       pip install pip-audit
       cd ${{ parameters.PROJECT_DIRECTORY }}
-      pip-audit -r requirements.txt
+      pip-audit --vulnerability-service osv .
     displayName: 'Run vulnerability scan'

--- a/eng/templates/shared/build-steps.yml
+++ b/eng/templates/shared/build-steps.yml
@@ -9,6 +9,7 @@ steps:
     displayName: 'Pip Authenticate'
     inputs:
       artifactFeeds: ${{ parameters.ArtifactFeed }}
+      onlyAddExtraIndex: false
   - task: UsePythonVersion@0
     inputs:
       versionSpec: ${{ parameters.PYTHON_VERSION }}

--- a/eng/templates/shared/build-steps.yml
+++ b/eng/templates/shared/build-steps.yml
@@ -22,8 +22,3 @@ steps:
       cd ${{ parameters.PROJECT_DIRECTORY }}
       python -m build
     displayName: 'Build Python ${{ parameters.PROJECT_NAME }}'
-  - bash: |
-      pip install pip-audit
-      cd ${{ parameters.PROJECT_DIRECTORY }}
-      pip-audit --vulnerability-service osv .
-    displayName: 'Run vulnerability scan'

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="PythonWorker_Internal_PublicPackages" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/nuget/v3/index.json" />
+    <add key="upstream" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="upstream" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/nuget/v3/index.json" />
+    <add key="PythonWorker_Internal_PublicPackages" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonWorker_Internal_PublicPackages/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="upstream" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/nuget/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -289,6 +289,9 @@ def install_extensions(extensions_dir):
         with open(extensions_dir / "extensions.csproj", "w") as f:
             f.write(EXTENSIONS_CSPROJ_TEMPLATE)
 
+    with open(extensions_dir / "NuGet.config", "w") as f:
+        f.write(ROOT_DIR.parent.joinpath("nuget.config").read_text())
+
     env = os.environ.copy()
     env["TERM"] = "xterm"  # ncurses 6.1 workaround
     try:
@@ -418,6 +421,9 @@ def webhost(c, clean=False, webhost_version=None, webhost_dir=None,
     create_webhost_folder(webhost_dir)
     version = branch_name or webhost_version
     extract_webhost_zip(version.replace("/", "-"), zip_path, webhost_dir)
+    # The webhost repo ships its own NuGet.config pointing to api.nuget.org.
+    # Overwrite it with the repo root config so the build uses the internal feed.
+    shutil.copy2(ROOT_DIR.parent / "nuget.config", webhost_dir / "NuGet.config")
     chmod_protobuf_generation_script(webhost_dir)
     compile_webhost(webhost_dir)
 

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -30,7 +30,7 @@ import zipfile
 
 from invoke import task
 
-from utils.constants import EXTENSIONS_CSPROJ_TEMPLATE, NUGET_CONFIG
+from utils.constants import EXTENSIONS_CSPROJ_TEMPLATE
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent
 BUILD_DIR = ROOT_DIR / 'build'
@@ -288,9 +288,6 @@ def install_extensions(extensions_dir):
     if not (extensions_dir / "extensions.csproj").exists():
         with open(extensions_dir / "extensions.csproj", "w") as f:
             f.write(EXTENSIONS_CSPROJ_TEMPLATE)
-
-    with open(extensions_dir / "NuGet.config", "w") as f:
-        f.write(NUGET_CONFIG)
 
     env = os.environ.copy()
     env["TERM"] = "xterm"  # ncurses 6.1 workaround

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -34,6 +34,7 @@ from utils.constants import EXTENSIONS_CSPROJ_TEMPLATE
 
 ROOT_DIR = pathlib.Path(__file__).parent.parent
 BUILD_DIR = ROOT_DIR / 'build'
+NUGET_CONFIG_PATH = ROOT_DIR.parent / 'nuget.config'
 WEBHOST_GITHUB_API = "https://api.github.com/repos/Azure/azure-functions-host"
 WEBHOST_GIT_REPO = "https://github.com/Azure/azure-functions-host/archive"
 WEBHOST_TAG_PREFIX = "v4."
@@ -115,6 +116,8 @@ def chmod_protobuf_generation_script(webhost_dir):
 
 def compile_webhost(webhost_dir):
     print(f"Compiling Functions Host from {webhost_dir}")
+    nuget_config_path = webhost_dir / "NuGet.config"
+    shutil.copy2(NUGET_CONFIG_PATH, nuget_config_path)
     # Build only the WebHost project (and its dependencies) instead of the
     # entire WebJobs.Script.sln. The solution also contains test projects,
     # benchmarks and isolated-worker samples that the tests never run; building
@@ -131,6 +134,7 @@ def compile_webhost(webhost_dir):
                 "/m:1",  # Disable parallel MSBuild
                 "/nodeReuse:false",  # Prevent MSBuild node reuse
                 f"--property:OutputPath={webhost_dir}/bin",  # Set output folder
+                f"--property:RestoreConfigFile={nuget_config_path}",
                 "/p:TreatWarningsAsErrors=false"
             ],
             check=True,
@@ -289,14 +293,17 @@ def install_extensions(extensions_dir):
         with open(extensions_dir / "extensions.csproj", "w") as f:
             f.write(EXTENSIONS_CSPROJ_TEMPLATE)
 
-    with open(extensions_dir / "NuGet.config", "w") as f:
-        f.write(ROOT_DIR.parent.joinpath("nuget.config").read_text())
+    nuget_config_path = extensions_dir / "NuGet.config"
+    shutil.copy2(NUGET_CONFIG_PATH, nuget_config_path)
 
     env = os.environ.copy()
     env["TERM"] = "xterm"  # ncurses 6.1 workaround
     try:
         subprocess.run(
-            args=["dotnet", "build", "-o", "."],
+            args=[
+                "dotnet", "build", "-o", ".",
+                f"--property:RestoreConfigFile={nuget_config_path}",
+            ],
             check=True,
             cwd=str(extensions_dir),
             stdout=sys.stdout,

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -116,6 +116,8 @@ def chmod_protobuf_generation_script(webhost_dir):
 
 def compile_webhost(webhost_dir):
     print(f"Compiling Functions Host from {webhost_dir}")
+    nuget_config_path = webhost_dir / "NuGet.config"
+    shutil.copy2(NUGET_CONFIG_PATH, nuget_config_path)
     # Build only the WebHost project (and its dependencies) instead of the
     # entire WebJobs.Script.sln. The solution also contains test projects,
     # benchmarks and isolated-worker samples that the tests never run; building
@@ -132,6 +134,7 @@ def compile_webhost(webhost_dir):
                 "/m:1",  # Disable parallel MSBuild
                 "/nodeReuse:false",  # Prevent MSBuild node reuse
                 f"--property:OutputPath={webhost_dir}/bin",  # Set output folder
+                f"--property:RestoreConfigFile={nuget_config_path}",
                 "/p:TreatWarningsAsErrors=false"
             ],
             check=True,

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -118,6 +118,25 @@ def compile_webhost(webhost_dir):
     print(f"Compiling Functions Host from {webhost_dir}")
     nuget_config_path = webhost_dir / "NuGet.config"
     shutil.copy2(NUGET_CONFIG_PATH, nuget_config_path)
+    # Pin packages to the highest versions cached in the upstream feed.
+    # The feed is offline-only (nuget.org blocked) so missing versions cause
+    # NU1102/NU1103 failures; these pins use the nearest available versions.
+    # Only the Python worker is under test — PowerShell/Isolated worker
+    # behaviour is not exercised, so older versions are safe here.
+    (webhost_dir / "Directory.Build.targets").write_text(
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<Project>\n'
+        '  <ItemGroup>\n'
+        '    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost"'
+        ' Version="1.1.0-alpha.1" PrivateAssets="all" />\n'
+        '    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4"'
+        ' Version="4.0.5203" PrivateAssets="all" />\n'
+        '    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6"'
+        ' Version="4.0.5201" PrivateAssets="all" />\n'
+        '  </ItemGroup>\n'
+        '</Project>\n',
+        encoding="utf-8",
+    )
     # Build only the WebHost project (and its dependencies) instead of the
     # entire WebJobs.Script.sln. The solution also contains test projects,
     # benchmarks and isolated-worker samples that the tests never run; building

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -116,8 +116,6 @@ def chmod_protobuf_generation_script(webhost_dir):
 
 def compile_webhost(webhost_dir):
     print(f"Compiling Functions Host from {webhost_dir}")
-    nuget_config_path = webhost_dir / "NuGet.config"
-    shutil.copy2(NUGET_CONFIG_PATH, nuget_config_path)
     # Build only the WebHost project (and its dependencies) instead of the
     # entire WebJobs.Script.sln. The solution also contains test projects,
     # benchmarks and isolated-worker samples that the tests never run; building
@@ -134,7 +132,6 @@ def compile_webhost(webhost_dir):
                 "/m:1",  # Disable parallel MSBuild
                 "/nodeReuse:false",  # Prevent MSBuild node reuse
                 f"--property:OutputPath={webhost_dir}/bin",  # Set output folder
-                f"--property:RestoreConfigFile={nuget_config_path}",
                 "/p:TreatWarningsAsErrors=false"
             ],
             check=True,

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -421,9 +421,6 @@ def webhost(c, clean=False, webhost_version=None, webhost_dir=None,
     create_webhost_folder(webhost_dir)
     version = branch_name or webhost_version
     extract_webhost_zip(version.replace("/", "-"), zip_path, webhost_dir)
-    # The webhost repo ships its own NuGet.config pointing to api.nuget.org.
-    # Overwrite it with the repo root config so the build uses the internal feed.
-    shutil.copy2(ROOT_DIR.parent / "nuget.config", webhost_dir / "NuGet.config")
     chmod_protobuf_generation_script(webhost_dir)
     compile_webhost(webhost_dir)
 

--- a/workers/tests/test_setup.py
+++ b/workers/tests/test_setup.py
@@ -116,27 +116,6 @@ def chmod_protobuf_generation_script(webhost_dir):
 
 def compile_webhost(webhost_dir):
     print(f"Compiling Functions Host from {webhost_dir}")
-    nuget_config_path = webhost_dir / "NuGet.config"
-    shutil.copy2(NUGET_CONFIG_PATH, nuget_config_path)
-    # Pin packages to the highest versions cached in the upstream feed.
-    # The feed is offline-only (nuget.org blocked) so missing versions cause
-    # NU1102/NU1103 failures; these pins use the nearest available versions.
-    # Only the Python worker is under test — PowerShell/Isolated worker
-    # behaviour is not exercised, so older versions are safe here.
-    (webhost_dir / "Directory.Build.targets").write_text(
-        '<?xml version="1.0" encoding="utf-8"?>\n'
-        '<Project>\n'
-        '  <ItemGroup>\n'
-        '    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost"'
-        ' Version="1.1.0-alpha.1" PrivateAssets="all" />\n'
-        '    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4"'
-        ' Version="4.0.5203" PrivateAssets="all" />\n'
-        '    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6"'
-        ' Version="4.0.5201" PrivateAssets="all" />\n'
-        '  </ItemGroup>\n'
-        '</Project>\n',
-        encoding="utf-8",
-    )
     # Build only the WebHost project (and its dependencies) instead of the
     # entire WebJobs.Script.sln. The solution also contains test projects,
     # benchmarks and isolated-worker samples that the tests never run; building
@@ -153,7 +132,6 @@ def compile_webhost(webhost_dir):
                 "/m:1",  # Disable parallel MSBuild
                 "/nodeReuse:false",  # Prevent MSBuild node reuse
                 f"--property:OutputPath={webhost_dir}/bin",  # Set output folder
-                f"--property:RestoreConfigFile={nuget_config_path}",
                 "/p:TreatWarningsAsErrors=false"
             ],
             check=True,

--- a/workers/tests/utils/constants.py
+++ b/workers/tests/utils/constants.py
@@ -45,23 +45,6 @@ EXTENSIONS_CSPROJ_TEMPLATE = """\
 </Project>
 """
 
-NUGET_CONFIG = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-   <packageSources>
-      <add key="nuget.org"
-        value="https://www.nuget.org/api/v2/" />
-      <add key="azure_app_service"
-        value="https://www.myget.org/F/azure-appservice/api/v2" />
-      <add key="azure_app_service_staging"
-        value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
-      <add key="buildTools"
-        value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
-      <add key="AspNetVNext"
-        value="https://www.myget.org/F/aspnetcore-dev/api/v3/index.json" />
-   </packageSources>
-</configuration>
-"""
 
 # PROJECT_ROOT refers to the path to azure-functions-python-worker
 # TODO: Find root folder without .parent


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Onboards all Python worker pipeline dependency restores to the Azure Artifacts public/upstream-public feed, eliminating direct traffic to PyPI and api.nuget.org.

### Changes
**pip / uv (Python packages)**
- All `PipAuthenticate@1` steps now use `public/upstream-public` with `onlyAddExtraIndex: false`, routing pip restores through the CFS
- Shell scripts forward `PIP_INDEX_URL` (set by `PipAuthenticate`) to `UV_DEFAULT_INDEX` so `uv` respects the same feed
- Removed `--prerelease=allow` from the main `uv` install command, replacing it with `--prerelease=if-necessary-or-explicit` to prevent transitive dependencies (e.g. aiohttp 4.0.0a1) from resolving to pre-release versions unnecessarily
- `pip-audit` removed from all vulnerability scan steps

**NuGet (.NET packages)**
- `nuget.config` updated to use `upstream-public` as the single package source
- Removed the per-build `"Configure NuGet feed"` bash steps that conditionally sed-patched `nuget.config` at runtime
- `ArtifactFeed` and `NuGetServiceConnection` parameters removed from job templates and all call sites

<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
