### PR TITLE
build: onboard npm installs to CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
-always-auth=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+always-auth=false

--- a/eng/templates/jobs/ci-emulator-tests.yml
+++ b/eng/templates/jobs/ci-emulator-tests.yml
@@ -148,7 +148,7 @@ jobs:
           df -h
           
           docker pull mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
-          docker run --detach --publish 8081:8081 --publish 1234:1234 mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
+          docker run --detach --env ENABLE_EXPLORER=false --publish 8081:8081 mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview
           docker ps
         displayName: "Start CosmosDB Emulator"
       - bash: |


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Disable the Cosmos DB emulator’s bundled Data Explorer during emulator tests.

The Data Explorer entrypoint runs `npm start` inside the container, causing CFSClean violations from `registry.npmjs.org`. The tests do not use Data Explorer, so this change sets `ENABLE_EXPLORER=false` and removes the unused port `1234` mapping.

Example run from the emulator tests shows CFS compliancy: https://azfunc.visualstudio.com/public/_build/results?buildId=295892&view=logs&j=7aa5b4c0-a883-5879-6f42-8b22e5f7c769&t=286d7a0d-3562-5b60-b497-88ed2b1d4742


<!-- please list issues, if any -->
Fixes #

---
<!--
Please add an informative description that covers the changes made by the pull request. 
This checklist is used to make sure that common issues in a pull request are addressed.
This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process.
-->

## Pull Request Checklist
<!--
Please fill out the following checklist to ensure compatibility across Python versions and programming models.
You can mark the following checkboxes as [x] to mark them during the PR creation itself.
-->
### Host-Worker Contract
- [ ] Does this PR impact the host-worker contract (e.g., gRPC messages, shared interfaces)?
   - If yes, have the changes been applied to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] proxy_worker (Python >= 3.13)
   - If no, please explain why:   

### Worker Execution Logic
- [ ] Does this PR affect worker execution logic (e.g., function invocation, bindings, lifecycle)?
If yes, please answer the following:

**Python Version Coverage**
   - [ ] Does this change apply to both Python <=3.12 and 3.13+?
   - If yes, have the changes been made to:
      - [ ] azure_functions_worker (Python <= 3.12)
      - [ ] runtimes/v1 / runtimes/v2 (Python >= 3.13)
   - If no, please explain why:

**Programming Model Compatibility (for Python 3.13+)**
- Does this change apply to both:
   - [ ] V1 programming model (runtimes/v1)?
   - [ ] V2 programming model (runtimes/v2)?
- Explanation (if limited to one model):

<!-- Thanks for using the checklist -->
