### PR TITLE
build: update azurefunctions-extensions-bindings-eventhub version to 1.0.0

### DIFF
--- a/workers/pyproject.toml
+++ b/workers/pyproject.toml
@@ -86,7 +86,7 @@ test-http-v2 = [
 test-deferred-bindings = [
     "azurefunctions-extensions-bindings-blob==1.1.2",
     "azurefunctions-extensions-bindings-cosmosdb==1.0.0b1",
-    "azurefunctions-extensions-bindings-eventhub==1.0.0b1; python_version < '3.14'"
+    "azurefunctions-extensions-bindings-eventhub==1.0.0; python_version < '3.14'"
 ]
 
 [build-system]

--- a/workers/pyproject.toml
+++ b/workers/pyproject.toml
@@ -85,8 +85,8 @@ test-http-v2 = [
 ]
 test-deferred-bindings = [
     "azurefunctions-extensions-bindings-blob==1.1.2",
-    "azurefunctions-extensions-bindings-eventhub==1.0.0; python_version < '3.14'"
     "azurefunctions-extensions-bindings-cosmosdb==1.0.0",
+    "azurefunctions-extensions-bindings-eventhub==1.0.0; python_version < '3.14'"
 ]
 
 [build-system]


### PR DESCRIPTION
Python Extension [azurefunctions-extensions-bindings-eventhub] Version [1.0.0](https://github.com/Azure/azure-functions-python-extensions/releases/tag/azurefunctions-extensions-bindings-eventhub/1.0.0)